### PR TITLE
Added mariadb database type

### DIFF
--- a/lib/core/jhipster/database_types.js
+++ b/lib/core/jhipster/database_types.js
@@ -3,6 +3,7 @@
 const TYPES = {
   sql: 'sql',
   mysql: 'mysql',
+  mariadb: 'mariadb',
   postgresql: 'postgresql',
   oracle: 'oracle',
   mongodb: 'mongodb',
@@ -10,7 +11,7 @@ const TYPES = {
 };
 
 function isSql(type) {
-  return TYPES.sql === type || TYPES.mysql === type || TYPES.postgresql === type || TYPES.oracle === type;
+  return TYPES.sql === type || TYPES.mysql === type || TYPES.postgresql === type || TYPES.oracle === type || TYPES.mariadb === type;
 }
 module.exports = {
   Types: TYPES,

--- a/lib/core/jhipster/field_types.js
+++ b/lib/core/jhipster/field_types.js
@@ -139,6 +139,7 @@ function getIsType(databaseType, callback) {
   switch (databaseType) {
     case DatabaseTypes.sql:
     case DatabaseTypes.mysql:
+    case DatabaseTypes.mariadb:
     case DatabaseTypes.postgresql:
     case DatabaseTypes.oracle:
       isType = isSQLType;
@@ -153,7 +154,7 @@ function getIsType(databaseType, callback) {
       callback && callback();
       throw new buildException(
           exceptions.IllegalArgument,
-          "The passed database type must either be 'sql', 'mysql', 'postgresql', 'oracle', 'mongodb', or 'cassandra'");
+          "The passed database type must either be 'sql', 'mysql', 'mariadb', 'postgresql', 'oracle', 'mongodb', or 'cassandra'");
   }
   return isType;
 }


### PR DESCRIPTION
Currently import-jdl fails, when 'mariadb' is set as database type.