### PR TITLE
Add json to jdl conversion support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ node_modules
 test/temp
 npm-debug.log
 out/
-.jhipster/
+/.jhipster/
+jhipster-jdl.jh
 .sonar
 coverage/*
 sonar-project.properties

--- a/lib/core/jdl_binary_option.js
+++ b/lib/core/jdl_binary_option.js
@@ -25,7 +25,13 @@ class JDLBinaryOption extends AbstractJDLOption {
   toString() {
     var entityNames = this.entityNames.join(', ');
     entityNames.slice(1, entityNames.length - 1);
-    var firstPart = `${this.name === BINARY_OPTIONS.BINARY_OPTIONS.PAGINATION ? 'paginate' : this.name} ${entityNames} with ${this.value}`;
+    var optionName = this.name;
+    if (this.name === BINARY_OPTIONS.BINARY_OPTIONS.PAGINATION) {
+      optionName = 'paginate';
+    } else if (this.name === BINARY_OPTIONS.BINARY_OPTIONS.SEARCH_ENGINE){
+      optionName  = 'search';
+    }
+    var firstPart = `${optionName} ${entityNames} with ${this.value}`;
     if (this.excludedNames.size() === 0) {
       return firstPart;
     }

--- a/lib/exceptions/exception_factory.js
+++ b/lib/exceptions/exception_factory.js
@@ -19,6 +19,7 @@ const EXCEPTIONS = {
   UnsupportedOperation: null,
   WrongAssociation: null,
   WrongFile: null,
+  WrongDir: null,
   WrongType: null,
   WrongValidation: null
 };

--- a/lib/export/jdl_exporter.js
+++ b/lib/export/jdl_exporter.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const fs = require('fs'),
+    buildException = require('../exceptions/exception_factory').buildException,
+    exceptions = require('../exceptions/exception_factory').exceptions;
+
+module.exports = {
+  exportToJDL: exportToJDL
+};
+
+function exportToJDL(jdl, path) {
+  if (!jdl) {
+    throw new buildException(
+        exceptions.NullPointer,
+        'A JDLObject has to be passed to be exported.');
+  }
+  if(!path) {
+    path = "./jhipster-jdl.jh"
+  }
+  fs.writeFileSync(path, jdl.toString());
+}

--- a/lib/parser/entity_parser.js
+++ b/lib/parser/entity_parser.js
@@ -111,12 +111,14 @@ function setOptions() {
     }
     option.entityNames.forEach(function (entityName) {
       if (option.name === BinaryOptions.MICROSERVICE) {
-        option.name = 'microserviceName';
-      }
-      if (option.name === UnaryOptions.NO_FLUENT_METHOD) {
+        entities[entityName]['microserviceName'] = option.value;
+      } else if (option.name === UnaryOptions.NO_FLUENT_METHOD) {
         entities[entityName]['fluentMethods'] = false;
+      } else if (option.name === BinaryOptions.ANGULAR_SUFFIX) {
+        entities[entityName]['angularJSSuffix'] = option.value;
+      } else {
+        entities[entityName][option.name] = option.value;
       }
-      entities[entityName][option.name] = option.value;
     });
   }
 }
@@ -145,7 +147,7 @@ function setFieldsOfEntity(entityName) {
     };
     let comment = formatComment(jdlField.comment);
     if (comment) {
-      fieldData.comment = comment;
+      fieldData.javadoc = comment;
     }
     if (isType(jdlField.type)) {
       fieldData.fieldType = jdlField.type;

--- a/lib/parser/json_parser.js
+++ b/lib/parser/json_parser.js
@@ -1,0 +1,194 @@
+'use strict';
+
+const _ = require('lodash'),
+    JDLObject = require('../core/jdl_object'),
+    JDLEntity = require('../core/jdl_entity'),
+    JDLField = require('../core/jdl_field'),
+    JDLValidation = require('../core/jdl_validation'),
+    JDLEnum = require('../core/jdl_enum'),
+    JDLRelationship = require('../core/jdl_relationship'),
+    JDLRelationships = require('../core/jdl_relationships'),
+    JDLUnaryOption = require('../core/jdl_unary_option'),
+    JDLBinaryOption = require('../core/jdl_binary_option'),
+    Validations = require('../core/jhipster/validations'),
+    RelationshipTypes = require('../core/jhipster/relationship_types').RELATIONSHIP_TYPES,
+    UnaryOptions = require('../core/jhipster/unary_options').UNARY_OPTIONS,
+    BinaryOptions = require('../core/jhipster/binary_options').BINARY_OPTIONS;
+
+module.exports = {
+  parseEntities: parseEntities,
+  parseServerOptions: parseServerOptions
+}
+
+/*
+ * Parses the json entities into JDL
+ * entities: json map with entity name as key and entity definition as value
+ * jdl: JDLObject to which the parsed entities are added. If undefined a new JDLObject is created.
+ * returns the JDLObject
+ */
+function parseEntities(entities, jdl) {
+  if (!entities) {
+    throw new buildException(
+      exceptions.NullPointer,
+      'Entities have to be passed to be converted.');
+  }
+  if (jdl === undefined) {
+      jdl = new JDLObject();
+  }
+  if (!jdl) {
+    throw new buildException(
+      exceptions.NullPointer,
+      'The JDLObject passed cannot be null.');
+  }
+  for (let i = 0, entityNames = Object.keys(entities); i < entityNames.length; i++) {
+    let entityName = entityNames[i];
+    let entity = entities[entityName];
+    jdl.addEntity(jsonToJDLEntity(entity, entityName));
+    addEnumsToJDL(jdl, entity);
+    addEntityOptionsToJDL(jdl, entity, entityName);
+  }
+  addRelationshipsToJDL(jdl, entities);
+  return jdl;
+}
+
+/*
+ * Parses the yo-rc.json into JDL
+ * yoRcJson: a yo-rc.json content containing a jhipster app configuration
+ * jdl: JDLObject to which the parsed options are added. If undefined a new JDLObject is created.
+ * returns the JDLObject
+ */
+function parseServerOptions(yoRcJson, jdl) {
+  if (jdl === undefined) {
+      jdl = new JDLObject();
+  }
+  if (!jdl) {
+    throw new buildException(
+      exceptions.NullPointer,
+      'The JDLObject passed cannot be null.');
+  }
+  for (let option of [UnaryOptions.SKIP_CLIENT, UnaryOptions.SKIP_SERVER])
+  if (yoRcJson['generator-jhipster'][option] === true) {
+    jdl.addOption( new JDLUnaryOption({name: option, value: yoRcJson['generator-jhipster'][option]}) );
+  }
+  return jdl;
+}
+
+function jsonToJDLEntity(entity, entityName) {
+  var jdlEntity = new JDLEntity( {name : entityName, tableName: entity.entityTableName, comment: entity.javadoc});
+  entity.fields.forEach(
+    field => jdlEntity.addField( jsonToJDLField(field) )
+  );
+  return jdlEntity;
+}
+
+function jsonToJDLField(field) {
+  var jdlField = new JDLField( { name: _.lowerFirst(field.fieldName), type: field.fieldType, comment: field.javadoc});
+  if(field.fieldValidateRules) {
+    field.fieldValidateRules.forEach( rule => jdlField.addValidation( jsonToJDLValidation (rule, field) ));
+  }
+  return jdlField;
+}
+
+function jsonToJDLValidation(rule, field) {
+  var ruleValueKey = 'fieldValidateRules' + _.upperFirst(rule);
+  return new JDLValidation( {name: rule, value: field[ruleValueKey]} );
+}
+
+function addEnumsToJDL(jdl, entity) {
+  var enums = [];
+  for (let field of entity.fields) {
+    if (field.fieldValues !== undefined) {
+      jdl.addEnum( new JDLEnum({ name: field.fieldType, values: field.fieldValues.split(',') }) );
+    }
+  }
+}
+
+/*
+ * Adds relationships for entites to JDL.
+ * The jdl passed must contain the jdl entities concerned by the relationships
+ */
+function addRelationshipsToJDL(jdl, entities) {
+  for (let i = 0, entityNames = Object.keys(entities); i < entityNames.length; i++) {
+    let entityName = entityNames[i];
+    let entity = entities[entityName];
+    for (let relationship of entity.relationships) {
+      let type;
+      let injectedFieldInFrom = relationship.relationshipName;
+      if (relationship.otherEntityField !== undefined && relationship.otherEntityField !== 'id') {
+        injectedFieldInFrom += '(' + relationship.otherEntityField + ')';
+      }
+      let injectedFieldInTo;
+      let isInjectedFieldInToRequired;
+      let otherEntity = entities[_.upperFirst(relationship.otherEntityName)];
+      if (otherEntity === undefined) {
+        continue;
+      }
+      for (let relationship2 of otherEntity.relationships) {
+        if (_.upperFirst(relationship2.otherEntityName) === entityName
+            && relationship2.otherEntityRelationshipName === relationship.relationshipName) {
+          // Bidirectional relationship
+          injectedFieldInTo = relationship2.relationshipName;
+          if (relationship2.otherEntityField !== undefined && relationship2.otherEntityField !== 'id') {
+            injectedFieldInTo += '(' + relationship2.otherEntityField + ')';
+          }
+          if (relationship2.relationshipValidateRules) {
+            isInjectedFieldInToRequired = true;
+          }
+        }
+      }
+      if (relationship.relationshipType === 'one-to-one' && relationship.ownerSide === true) {
+        type = RelationshipTypes.ONE_TO_ONE;
+      }
+      if (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === true) {
+        type = RelationshipTypes.MANY_TO_MANY;
+      }
+      if (relationship.relationshipType === 'many-to-one') {
+        if (injectedFieldInTo !== undefined) {
+          // This is a bidirectional relationship so consider it as a OneToMany
+          jdl.addRelationship( new JDLRelationship( {
+            from: jdl.entities[_.upperFirst(relationship.otherEntityName)],
+            to: jdl.entities[entityName],
+            type: RelationshipTypes.ONE_TO_MANY,
+            injectedFieldInFrom: injectedFieldInTo,
+            injectedFieldInTo: injectedFieldInFrom,
+            isInjectedFieldInFromRequired: isInjectedFieldInToRequired,
+            isInjectedFieldInToRequired: relationship.relationshipValidateRules
+          }));
+        } else {
+          // Unidirectional ManyToOne
+          type = RelationshipTypes.MANY_TO_ONE;
+        }
+      }
+      if (type !== undefined) {
+        jdl.addRelationship( new JDLRelationship( {
+          from: jdl.entities[entityName],
+          to: jdl.entities[_.upperFirst(relationship.otherEntityName)],
+          type: type,
+          injectedFieldInFrom: injectedFieldInFrom,
+          injectedFieldInTo: injectedFieldInTo,
+          isInjectedFieldInFromRequired: relationship.relationshipValidateRules,
+          isInjectedFieldInToRequired: isInjectedFieldInToRequired
+        }));
+      }
+    }
+  }
+}
+
+function addEntityOptionsToJDL(jdl, entity, entityName) {
+  if (entity.fluentMethods === false) {
+    jdl.addOption( new JDLUnaryOption({name: UnaryOptions.NO_FLUENT_METHOD, entityNames: [entityName]}) );
+  }
+  for (let option of [BinaryOptions.DTO, BinaryOptions.PAGINATION, BinaryOptions.SERVICE, BinaryOptions.SEARCH_ENGINE ] ) {
+    if (entity[option] && entity[option] !== 'no') {
+      jdl.addOption( new JDLBinaryOption({name: option, value: entity[option], entityNames: [entityName]}) );
+    }
+  }
+  // angularSuffix in BINARY_OPTIONS, angularJSSuffix in Json
+  if (entity.angularJSSuffix !== undefined) {
+    jdl.addOption( new JDLBinaryOption({name: BinaryOptions.ANGULAR_SUFFIX, value: entity.angularJSSuffix, entityNames: [entityName]}) );
+  }
+  // microservice in BINARY_OPTIONS, microserviceName in Json
+  if (entity.microserviceName !== undefined) {
+    jdl.addOption( new JDLBinaryOption({name: BinaryOptions.MICROSERVICE, value: entity.microserviceName, entityNames: [entityName]}) );
+  }
+}

--- a/lib/reader/json_reader.js
+++ b/lib/reader/json_reader.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const fs = require('fs'),
+  Parser = require('../parser/json_parser'),
+  Reader = require('../reader/json_file_reader'),
+  buildException = require('../exceptions/exception_factory').buildException,
+  exceptions = require('../exceptions/exception_factory').exceptions;
+
+module.exports = {
+  parseFromDir: parseFromDir
+};
+
+/* Parse the given jhipster app dir and return a JDLObject */
+function parseFromDir(dir) {
+  var isDir = false;
+  if (!dir) {
+    throw new buildException(
+        exceptions.IllegalArgument, 'The app directory must be passed.');
+  }
+  try {
+    isDir = fs.statSync(dir).isDirectory();
+  } catch (error) { // doesn't exist
+    isDir = false;
+  }
+  if (!isDir) {
+    throw new buildException(
+        exceptions.WrongDir,
+        `The passed dir must exist and must be a directory.`);
+  }
+  var jdl = Parser.parseServerOptions(Reader.readEntityJSON(dir + '/.yo-rc.json'));
+  var entityDir = dir + '/.jhipster';
+  var isJhipsterDirectory = false;
+  try {
+    isJhipsterDirectory = fs.statSync(entityDir).isDirectory();
+  } catch (error) {
+    // .jhipster dir doesn't exist'
+    return jdl;
+  }
+  if (!isJhipsterDirectory) {
+    throw new buildException(
+        exceptions.WrongDir,
+        `'${entityDir}' must be a directory.`);
+  }
+  var entities = {};
+  fs.readdirSync(entityDir).forEach(function(file) {
+    if(file.slice(file.length - 5, file.length) === '.json') {
+      var entityName = file.slice(0, file.length - 5);
+      try {
+        entities[entityName] = Reader.readEntityJSON(entityDir + '/' + file);
+      } catch (error) {
+        // Not an entity file, not adding
+      }
+    }
+  });
+  Parser.parseEntities(entities, jdl);
+  return jdl;
+}

--- a/module/index.js
+++ b/module/index.js
@@ -7,8 +7,10 @@ const BINARY_OPTIONS = require('../lib/core/jhipster/binary_options'),
     VALIDATIONS = require('../lib/core/jhipster/validations'),
     DATABASE_TYPES = require('../lib/core/jhipster/database_types'),
     JDLReader = require('../lib/reader/jdl_reader'),
+    JsonReader = require('../lib/reader/json_reader'),
     convertToJDL = require('../lib/parser/jdl_parser').parse,
     convertToJHipsterJSON = require('../lib/parser/entity_parser').parse,
+    JsonParser = require('../lib/parser/json_parser'),
     JDLObject = require('../lib/core/jdl_object'),
     JDLEntity = require('../lib/core/jdl_entity'),
     JDLField = require('../lib/core/jdl_field'),
@@ -20,6 +22,7 @@ const BINARY_OPTIONS = require('../lib/core/jhipster/binary_options'),
     JDLBinaryOption = require('../lib/core/jdl_binary_option'),
     exportToJSON = require('../lib/export/json_exporter').exportToJSON,
     createJHipsterJSONFolder = require('../lib/export/json_exporter').createJHipsterJSONFolder,
+    exportToJDL = require('../lib/export/jdl_exporter').exportToJDL,
     toFilePath = require('../lib/reader/json_file_reader').toFilePath,
     readEntityJSON = require('../lib/reader/json_file_reader').readEntityJSON,
     ReservedKeywords = require('../lib/core/jhipster/reserved_keywords'),
@@ -51,11 +54,18 @@ module.exports = {
   /* JDL reading */
   parse: JDLReader.parse,
   parseFromFiles: JDLReader.parseFromFiles,
+  /* Json reading */
+  parseJsonFromDir: JsonReader.parseFromDir,
   /* JDL conversion */
   convertToJDL: convertToJDL,
   convertToJHipsterJSON: convertToJHipsterJSON,
+  /* Json conversion */
+  convertJsonEntitiesToJDL: JsonParser.parseEntities,
+  convertJsonServerOptionsToJDL: JsonParser.parseServerOptions,
   /* JSON exporting */
   exportToJSON: exportToJSON,
+  /* JDL exporting */
+  exportToJDL: exportToJDL,
   /* JDL utils */
   isJDLFile: JDLReader.checkFileIsJDLFile,
   /* JSON utils */

--- a/test/spec/export/jdl_exporter_test.js
+++ b/test/spec/export/jdl_exporter_test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const expect = require('chai').expect,
+    fs = require('fs'),
+    readEntityJSON = require('../../../lib/reader/json_file_reader').readEntityJSON,
+    Exporter = require('../../../lib/export/jdl_exporter'),
+    JDLReader = require('../../../lib/reader/jdl_reader'),
+    JDLParser = require('../../../lib/parser/jdl_parser'),
+    EntityParser = require('../../../lib/parser/entity_parser'),
+    JsonParser = require('../../../lib/parser/json_parser'),
+    parseFromDir = require('../../../lib/reader/json_reader').parseFromDir;
+
+describe('::exportToJDL', function () {
+  describe('when passing invalid parameters', function () {
+    describe('such as undefined', function () {
+      it('throws an error', function () {
+        try {
+          Exporter.exportToJDL();
+          fail();
+        } catch (error) {
+          expect(error.name).to.eq('NullPointerException')
+        }
+      });
+    });
+  });
+  describe('when passing valid arguments', function () {
+    describe('when exporting json to entity JDL', function () {
+      it('exports it', function () {
+        var jdl = parseFromDir('./test/test_files/jhipster_app');
+        Exporter.exportToJDL(jdl);
+        expect(fs.statSync('./jhipster-jdl.jh').isFile()).to.be.true;
+
+        var input = JDLReader.parseFromFiles(['./jhipster-jdl.jh']);
+        var entities_after = EntityParser.parse({jdlObject: JDLParser.parse(input, 'sql'), databaseType: 'sql'});
+        var entities_before = {};
+
+
+        for (let entityName of ['Country', 'Department', 'Employee', 'Job', 'JobHistory', 'Location', 'Region', 'Task'])  {
+          entities_before[entityName] = readEntityJSON('./test/test_files/jhipster_app/.jhipster/' + entityName + '.json');
+          entities_before[entityName].changelogDate = entities_after[entityName].changelogDate;
+          if (entities_before[entityName].javadoc === undefined) {
+            entities_before[entityName].javadoc = undefined;
+          }
+          // Sort arrays to ease comparison
+          entities_before[entityName].fields.sort( (f1, f2) => (f1.fieldName < f2.fieldName) - (f1.fieldName > f2.fieldName));
+          entities_after[entityName].fields.sort( (f1, f2) => (f1.fieldName < f2.fieldName) - (f1.fieldName > f2.fieldName));
+          entities_before[entityName].relationships.sort( (r1, r2) => (r1.relationshipName < r2.relationshipName) - (r1.relationshipName > r2.relationshipName));
+          entities_after[entityName].relationships.sort( (r1, r2) => (r1.relationshipName < r2.relationshipName) - (r1.relationshipName > r2.relationshipName));
+        }
+        expect(entities_after).to.deep.eq(entities_before);
+
+        // clean up the mess...
+        fs.unlinkSync('./jhipster-jdl.jh');
+      });
+    });
+  });
+});

--- a/test/spec/parser/json_parser_test.js
+++ b/test/spec/parser/json_parser_test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const expect = require('chai').expect,
+    Reader = require('../../../lib/reader/json_file_reader'),
+    Parser = require('../../../lib/parser/json_parser'),
+    RelationshipTypes = require('../../../lib/core/jhipster/relationship_types').RELATIONSHIP_TYPES,
+    UnaryOptions = require('../../../lib/core/jhipster/unary_options').UNARY_OPTIONS,
+    BinaryOptions = require('../../../lib/core/jhipster/binary_options').BINARY_OPTIONS,
+    BinaryOptionValues = require('../../../lib/core/jhipster/binary_options').BINARY_OPTION_VALUES;
+
+describe('::parse', function () {
+  describe('when parsing a Json entity to JDL', function () {
+    it('parses entity javadoc', function () {
+      var entities = {
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Employee.comment).eq('The Employee entity.');
+    });
+    it('parses tableName', function () {
+      var entities = {
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Employee.tableName).eq('emp');
+    });
+    it('parses mandatory fields', function () {
+      var entities = {
+        'Country': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Country.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Country.fields.countryId.type).eq('Long');
+      expect(content.entities.Country.fields.countryName.type).eq('String');
+
+    });
+    it('parses field javadoc', function () {
+      var entities = {
+        'Country': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Country.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Country.fields.countryId.comment).eq('The country Id');
+      expect(content.entities.Country.fields.countryName.comment).to.be.undefined;
+    });
+    it('parses validations', function () {
+      var entities = {
+        'Department': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Department.json'),
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Department.fields.departmentName.validations.required.name).eq('required');
+      expect(content.entities.Department.fields.departmentName.validations.required.value).to.be.undefined;
+      expect(content.entities.Employee.fields.salary.validations.min.value).eq(10000);
+      expect(content.entities.Employee.fields.salary.validations.max.value).eq(1000000);
+      expect(content.entities.Employee.fields.employeeId.validations).to.be.empty;
+    });
+    it('parses enums', function () {
+      var entities = {
+        'JobHistory': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/JobHistory.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.enums.Language.name).eq('Language');
+      expect(content.enums.Language.values.has('FRENCH')).to.be.true;
+      expect(content.enums.Language.values.has('ENGLISH')).to.be.true;
+      expect(content.enums.Language.values.has('SPANISH')).to.be.true;
+    });
+    it('parses options', function () {
+      var entities = {
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.options.filter( o => o.name === BinaryOptions.DTO && o.value === BinaryOptionValues.dto.MAPSTRUCT && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === BinaryOptions.PAGINATION && o.value === BinaryOptionValues.pagination['INFINITE-SCROLL'] && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === BinaryOptions.SERVICE && o.value === BinaryOptionValues.service.SERVICE_CLASS && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === BinaryOptions.SEARCH_ENGINE && o.value === BinaryOptionValues.searchEngine.ELASTIC_SEARCH && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === BinaryOptions.MICROSERVICE && o.value === 'mymicroservice' && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === BinaryOptions.ANGULAR_SUFFIX && o.value === 'myentities' && o.entityNames.has('Employee')).length).eq(1);
+      expect(content.options.filter( o => o.name === UnaryOptions.NO_FLUENT_METHOD && o.entityNames.has('Employee')).length).eq(1);
+    });
+  });
+
+  describe('when parsing Json entities to JDL', function () {
+    it('parses them', function () {
+      var entities = {
+        'Country': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Country.json'),
+        'Department': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Department.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.entities.Country).not.to.be.undefined;
+      expect(content.entities.Department).not.to.be.undefined;
+    });
+    it('parses unidirectional OneToOne relationships', function () {
+      var entities = {
+        'Location': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Location.json'),
+        'Department': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Department.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.OneToOne).has.property('OneToOne_Department{location}_Location');
+    });
+    it('parses bidirectional OneToOne relationships', function () {
+      var entities = {
+        'Country': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Country.json'),
+        'Region': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Region.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.OneToOne).has.property('OneToOne_Country{region}_Region{country}');
+    });
+    it('parses bidirectional OneToMany relationships', function () {
+      var entities = {
+        'Department': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Department.json'),
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.OneToMany).has.property('OneToMany_Department{employee}_Employee{department(foo)}');
+    });
+    it('parses unidirectional ManyToOne relationships', function () {
+      var entities = {
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.ManyToOne).has.property('ManyToOne_Employee{manager}_Employee');
+    });
+    it('parses ManyToMany relationships', function () {
+      var entities = {
+        'Job': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Job.json'),
+        'Task': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Task.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.ManyToMany).has.property('ManyToMany_Job{task(title)}_Task{job}');
+    });
+    it('parses required relationships in owner', function () {
+      var entities = {
+        'Department': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Department.json'),
+        'Employee': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Employee.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.OneToMany['OneToMany_Department{employee}_Employee{department(foo)}'].isInjectedFieldInFromRequired).to.be.true;
+      expect(content.relationships.relationships.OneToMany['OneToMany_Department{employee}_Employee{department(foo)}'].isInjectedFieldInToRequired).to.be.undefined;
+    });
+    it('parses required relationships in owned', function () {
+      var entities = {
+        'Job': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Job.json'),
+        'Task': Reader.readEntityJSON('./test/test_files/jhipster_app/.jhipster/Task.json')
+      };
+      var content = Parser.parseEntities(entities);
+      expect(content.relationships.relationships.ManyToMany['ManyToMany_Job{task(title)}_Task{job}'].isInjectedFieldInToRequired).to.be.true;
+      expect(content.relationships.relationships.ManyToMany['ManyToMany_Job{task(title)}_Task{job}'].isInjectedFieldInFromRequired).to.be.undefined;
+    });
+  });
+
+  describe('when parsing app config file to JDL', function () {
+    it('parses server options', function () {
+      var yoRcJson = Reader.readEntityJSON('./test/test_files/jhipster_app/.yo-rc.json');
+      var content = Parser.parseServerOptions(yoRcJson);
+      expect(content.options.filter( o => o.name === UnaryOptions.SKIP_CLIENT && o.entityNames.has('*')).length).eq(1);
+      expect(content.options.filter( o => o.name === UnaryOptions.SKIP_SERVER && o.entityNames.has('*')).length).eq(1);
+    });
+  });
+
+});

--- a/test/spec/reader/json_reader_test.js
+++ b/test/spec/reader/json_reader_test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const expect = require('chai').expect,
+    fs = require('fs'),
+    fail = expect.fail,
+    parseFromDir = require('../../../lib/reader/json_reader').parseFromDir,
+    UnaryOptions = require('../../../lib/core/jhipster/unary_options').UNARY_OPTIONS;
+
+describe('::parseFromDir', function() {
+  describe('when passing invalid parameters', function () {
+    describe('such as nil', function () {
+      it('throws an error', function () {
+        try {
+          parseFromDir(null);
+          fail();
+        } catch (error) {
+          expect(error.name).to.eq('IllegalArgumentException')
+        }
+      });
+    });
+    describe("such as a file", function () {
+      it('throws an error', function () {
+        try {
+          parseFromDir('../../test_files/invalid_file.txt');
+          fail();
+        } catch (error) {
+          expect(error.name).to.eq('WrongDirException')
+        }
+      });
+    });
+    describe('such as a dir that does not exist', function () {
+      it('throws an error', function () {
+        try {
+          parseFromDir('nodir');
+          fail();
+        } catch (error) {
+          expect(error.name).to.eq('WrongDirException')
+        }
+      });
+    });
+  });
+  describe('when passing valid arguments', function () {
+    describe('when reading a jhipster app dir', function () {
+      it('reads it', function () {
+        var content = parseFromDir('./test/test_files/jhipster_app');
+        expect(content.entities.Country).not.to.be.undefined;
+        expect(content.entities.Department).not.to.be.undefined;
+        expect(content.entities.Employee).not.to.be.undefined;
+        expect(content.entities.Job).not.to.be.undefined;
+        expect(content.entities.JobHistory).not.to.be.undefined;
+        expect(content.entities.Region).not.to.be.undefined;
+        expect(content.entities.Task).not.to.be.undefined;
+        expect(content.entities.NoEntity).to.be.undefined;
+        expect(content.entities.BadEntity).to.be.undefined;
+        expect(content.options.filter( o => o.name === UnaryOptions.SKIP_CLIENT).length).eq(1);
+        expect(content.options.filter( o => o.name === UnaryOptions.SKIP_SERVER).length).eq(1);
+      });
+    });
+  });
+});

--- a/test/test_files/jhipster_app/.jhipster/BadEntity.json
+++ b/test/test_files/jhipster_app/.jhipster/BadEntity.json
@@ -1,0 +1,1 @@
+Not an entity

--- a/test/test_files/jhipster_app/.jhipster/Country.json
+++ b/test/test_files/jhipster_app/.jhipster/Country.json
@@ -1,0 +1,29 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "region",
+            "otherEntityName": "region",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "country"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "countryId",
+            "fieldType": "Long",
+            "javadoc": "The country Id"
+        },
+        {
+            "fieldName": "countryName",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160926101210",
+    "entityTableName": "country",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/Department.json
+++ b/test/test_files/jhipster_app/.jhipster/Department.json
@@ -1,0 +1,39 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "location",
+            "otherEntityName": "location",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "department"
+        },
+        {
+            "relationshipType": "one-to-many",
+            "relationshipValidateRules": "required",
+            "relationshipName": "employee",
+            "otherEntityName": "employee",
+            "otherEntityRelationshipName": "department"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "departmentId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "departmentName",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "required"
+            ]
+        }
+    ],
+    "changelogDate": "20160926092246",
+    "entityTableName": "department",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no",
+    "fluentMethods": false
+}

--- a/test/test_files/jhipster_app/.jhipster/Employee.json
+++ b/test/test_files/jhipster_app/.jhipster/Employee.json
@@ -1,0 +1,72 @@
+{
+    "relationships": [
+        {
+            "relationshipName": "department",
+            "otherEntityName": "department",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "foo"
+        },
+        {
+            "relationshipType": "one-to-many",
+            "relationshipName": "job",
+            "otherEntityName": "job",
+            "otherEntityRelationshipName": "employee"
+        },
+        {
+            "relationshipType": "many-to-one",
+            "relationshipName": "manager",
+            "otherEntityName": "employee",
+            "otherEntityField": "id"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "employeeId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "firstName",
+            "javadoc": "The firstname attribute.",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "lastName",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "email",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "phoneNumber",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "hireDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldName": "salary",
+            "fieldType": "Long",
+            "fieldValidateRules": [
+                "min", "max"
+            ],
+            "fieldValidateRulesMin": 10000,
+            "fieldValidateRulesMax": 1000000
+        },
+        {
+            "fieldName": "commissionPct",
+            "fieldType": "Long"
+        }
+    ],
+    "changelogDate": "20160926083805",
+    "javadoc": "The Employee entity.",
+    "entityTableName": "emp",
+    "dto": "mapstruct",
+    "pagination": "infinite-scroll",
+    "service": "serviceClass",
+    "fluentMethods": false,
+    "searchEngine": "elasticsearch",
+    "angularJSSuffix": "myentities",
+    "microserviceName": "mymicroservice"
+}

--- a/test/test_files/jhipster_app/.jhipster/Job.json
+++ b/test/test_files/jhipster_app/.jhipster/Job.json
@@ -1,0 +1,42 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipName": "employee",
+            "otherEntityName": "employee",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "id"
+        },
+        {
+            "relationshipType": "many-to-many",
+            "otherEntityRelationshipName": "job",
+            "relationshipName": "task",
+            "otherEntityName": "task",
+            "otherEntityField": "title",
+            "ownerSide": true
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "jobId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "jobTitle",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "minSalary",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "maxSalary",
+            "fieldType": "Long"
+        }
+    ],
+    "changelogDate": "20160924093047",
+    "entityTableName": "job",
+    "dto": "no",
+    "pagination": "pagination",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/JobHistory.json
+++ b/test/test_files/jhipster_app/.jhipster/JobHistory.json
@@ -1,0 +1,49 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "job",
+            "otherEntityName": "job",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "jobHistory"
+        },
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "department",
+            "otherEntityName": "department",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "jobHistory"
+        },
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "employee",
+            "otherEntityName": "employee",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "jobHistory"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "startDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldName": "endDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldName": "language",
+            "fieldType": "Language",
+            "fieldValues": "FRENCH,ENGLISH,SPANISH"
+        }
+    ],
+    "changelogDate": "20160924092444",
+    "entityTableName": "job_history",
+    "dto": "no",
+    "pagination": "infinite-scroll",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/Location.json
+++ b/test/test_files/jhipster_app/.jhipster/Location.json
@@ -1,0 +1,40 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "country",
+            "otherEntityName": "country",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "location"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "locationId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "streetAddress",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "postalCode",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "city",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "stateProvince",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160924092439",
+    "entityTableName": "location",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/NoEntity.txt
+++ b/test/test_files/jhipster_app/.jhipster/NoEntity.txt
@@ -1,0 +1,28 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "country",
+            "otherEntityName": "country",
+            "otherEntityField": "foo",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "region"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "regionId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "regionName",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160926083800",
+    "entityTableName": "region",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/Region.json
+++ b/test/test_files/jhipster_app/.jhipster/Region.json
@@ -1,0 +1,27 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "one-to-one",
+            "relationshipName": "country",
+            "otherEntityName": "country",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "region"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "regionId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "regionName",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160926083800",
+    "entityTableName": "region",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.jhipster/Task.json
+++ b/test/test_files/jhipster_app/.jhipster/Task.json
@@ -1,0 +1,32 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipType": "many-to-many",
+            "relationshipValidateRules": "required",
+            "relationshipName": "job",
+            "otherEntityName": "job",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "task"
+        }
+    ],
+    "fields": [
+        {
+            "fieldName": "taskId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "title",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "description",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160926100704",
+    "entityTableName": "task",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/test/test_files/jhipster_app/.yo-rc.json
+++ b/test/test_files/jhipster_app/.yo-rc.json
@@ -1,0 +1,31 @@
+{
+  "generator-jhipster": {
+    "jhipsterVersion": "3.7.1",
+    "baseName": "standard",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "serverPort": "8080",
+    "authenticationType": "session",
+    "hibernateCache": "ehcache",
+    "clusteredHttpSession": false,
+    "websocket": false,
+    "databaseType": "sql",
+    "devDatabaseType": "h2Memory",
+    "prodDatabaseType": "postgresql",
+    "searchEngine": false,
+    "buildTool": "gradle",
+    "enableSocialSignIn": false,
+    "rememberMeKey": "5f1100e7eae25e2abe32d7b2031ac1f2acc778d8",
+    "useSass": false,
+    "applicationType": "monolith",
+    "testFrameworks": [],
+    "jhiPrefix": "jhi",
+    "enableTranslation": true,
+    "nativeLanguage": "en",
+    "languages": [
+      "en"
+    ],
+    "skipClient": true,
+    "skipServer": true
+  }
+}


### PR DESCRIPTION
One of the test does a json -> jdl -> json and compares the initial and produced json. This is useful to detect issues during one of the stages. And actually I found bugs which are fixed in this PR:
 * the JDL field `comment` was not converted to json `javadoc`
 * the JDL `noFluentMethod` was output in the json together with `"fluentMethods": false`
 * the JDL `angularSuffix` was not converted to json `angularJSSuffix`
 * the json `searchEngine` was not converted to JDL `search`

Fix #64