### PR TITLE
Parse server options from jhipster config field instead of full .yo-rc.json

### DIFF
--- a/lib/parser/json_parser.js
+++ b/lib/parser/json_parser.js
@@ -52,12 +52,12 @@ function parseEntities(entities, jdl) {
 }
 
 /*
- * Parses the yo-rc.json into JDL
- * yoRcJson: a yo-rc.json content containing a jhipster app configuration
+ * Parses the jhipster configuration into JDL
+ * jhConfig: the jhipster config ('generator-jhipster' in .yo-rc.json)
  * jdl: JDLObject to which the parsed options are added. If undefined a new JDLObject is created.
  * returns the JDLObject
  */
-function parseServerOptions(yoRcJson, jdl) {
+function parseServerOptions(jhConfig, jdl) {
   if (jdl === undefined) {
       jdl = new JDLObject();
   }
@@ -67,8 +67,8 @@ function parseServerOptions(yoRcJson, jdl) {
       'The JDLObject passed cannot be null.');
   }
   for (let option of [UnaryOptions.SKIP_CLIENT, UnaryOptions.SKIP_SERVER])
-  if (yoRcJson['generator-jhipster'][option] === true) {
-    jdl.addOption( new JDLUnaryOption({name: option, value: yoRcJson['generator-jhipster'][option]}) );
+  if (jhConfig[option] === true) {
+    jdl.addOption( new JDLUnaryOption({name: option, value: jhConfig[option]}) );
   }
   return jdl;
 }

--- a/lib/reader/json_reader.js
+++ b/lib/reader/json_reader.js
@@ -27,7 +27,7 @@ function parseFromDir(dir) {
         exceptions.WrongDir,
         `The passed dir must exist and must be a directory.`);
   }
-  var jdl = Parser.parseServerOptions(Reader.readEntityJSON(dir + '/.yo-rc.json'));
+  var jdl = Parser.parseServerOptions(Reader.readEntityJSON(dir + '/.yo-rc.json')['generator-jhipster']);
   var entityDir = dir + '/.jhipster';
   var isJhipsterDirectory = false;
   try {

--- a/test/spec/parser/json_parser_test.js
+++ b/test/spec/parser/json_parser_test.js
@@ -150,7 +150,7 @@ describe('::parse', function () {
   describe('when parsing app config file to JDL', function () {
     it('parses server options', function () {
       var yoRcJson = Reader.readEntityJSON('./test/test_files/jhipster_app/.yo-rc.json');
-      var content = Parser.parseServerOptions(yoRcJson);
+      var content = Parser.parseServerOptions(yoRcJson['generator-jhipster']);
       expect(content.options.filter( o => o.name === UnaryOptions.SKIP_CLIENT && o.entityNames.has('*')).length).eq(1);
       expect(content.options.filter( o => o.name === UnaryOptions.SKIP_SERVER && o.entityNames.has('*')).length).eq(1);
     });


### PR DESCRIPTION
This is more consistent.
In generator-jhipster, this is `this.config` and you don't need to wrap it.