### PR TITLE
Modified npm scripts so that they can be run on Windows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 lib/dsl/pegjs_parser.js
+coverage

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "DSL"
   ],
   "scripts": {
-    "lint": "./node_modules/eslint/bin/eslint.js .",
-    "lint-fix": "./node_modules/eslint/bin/eslint.js . --fix",
+    "lint": "eslint .",
+    "lint-fix": "eslint.js . --fix",
     "check-dependencies": "node ./scripts/check_dependencies.js",
-    "test": "./node_modules/mocha/bin/mocha test",
-    "coverage": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha test -- -t 5000",
-    "peg-parse": "./node_modules/pegjs/bin/pegjs -o lib/dsl/pegjs_parser.js lib/dsl/grammar.txt"
+    "test": "mocha test",
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha test --",
+    "peg-parse": "pegjs -o lib/dsl/pegjs_parser.js lib/dsl/grammar.txt"
   },
   "homepage": "https://github.com/jhipster/jhipster-core#readme",
   "repository": {
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "eslint": "3.14.1",
+    "eslint": "3.15.0",
     "istanbul": "0.4.5",
     "mocha": "3.2.0",
     "mocha-clean": "1.0.0",


### PR DESCRIPTION
Add `coverage` directory to `.eslintignore`