### PR TITLE
fix example JDL DTO option

### DIFF
--- a/lib/dsl/example.jh
+++ b/lib/dsl/example.jh
@@ -106,6 +106,6 @@ relationship OneToOne {
 paginate JobHistory, Employee with infinite-scroll
 paginate Job with pagination
 
-dto Employee with mapstruct
+dto * with mapstruct
 
 service Employee with serviceClass


### PR DESCRIPTION
The DTO option needs to be enabled for any entities with a relationship to an entity using DTOs.  Employee has a relationship with every entity, so I replaced it with `*`

Related to https://github.com/jhipster/generator-jhipster/issues/6096