### PR TITLE
Fix validations rules

### DIFF
--- a/lib/core/jdl_validation.js
+++ b/lib/core/jdl_validation.js
@@ -37,7 +37,7 @@ class JDLValidation {
 
   toString() {
     let string = `${this.name}`;
-    if (this.value) {
+    if (this.value || this.value === 0) {
       string += `(${this.value})`;
     }
     return string;


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/6010

For example, when `name=min` and `value=0`, the result is `min` instead of `min(0)`
It's because the condition `if (this.value)` will evaluate to `true` if value is not:
- null
- undefined
- NaN
- empty string
- 0
- false

So the 0 need to be excluded here

Hope I won't break something, I'm trusting on your tests @MathieuAA 
But plz, check closely if there is any impact