### PR TITLE
Support Keywords as Identifiers

### DIFF
--- a/lib/dsl/poc/lexer.js
+++ b/lib/dsl/poc/lexer.js
@@ -33,7 +33,7 @@ function createToken(config) {
   // a Concise way to resolve the problem without manually adding the "longer_alt" property dozens of times.
   if (_.isString(config.pattern) && namePattern.test(config.pattern)) {
     config.longer_alt = NAME;
-    // 'application' IS-A KEYWORD which in turn IS-A NAME --> all keywords are now valid identifiers.
+    // 'application' IS-A KEYWORD which in turn IS-A NAME
     config.parent = KEYWORD;
   }
 

--- a/lib/dsl/poc/lexer.js
+++ b/lib/dsl/poc/lexer.js
@@ -17,6 +17,15 @@ const namePattern = /[a-zA-Z_][a-zA-Z_\d]*/;
 // syntax errors do.
 const NAME = chevrotain.createToken({ name: 'NAME', pattern: namePattern });
 
+// by defining keywords to 'inherit' from NAME, keywords become unreserved at the parser level.
+// so CONSUME(t.NAME) could now also match a token of type t.APPLICATION.
+// - as I believe is the case with the PEGJS implementation.
+// - Note that "parser level" is different than any validations performs after parsing i.e
+//   in reserved_keywords.js
+const KEYWORD = chevrotain.createToken({
+  name: 'KEYWORD', pattern: Lexer.NA, longer_alt: NAME, parent: NAME
+});
+
 function createToken(config) {
   // JDL has a great many keywords. Keywords can conflict with identifiers in a parsing
   // library with a separate lexing phase.
@@ -24,6 +33,8 @@ function createToken(config) {
   // a Concise way to resolve the problem without manually adding the "longer_alt" property dozens of times.
   if (_.isString(config.pattern) && namePattern.test(config.pattern)) {
     config.longer_alt = NAME;
+    // 'application' IS-A KEYWORD which in turn IS-A NAME --> all keywords are now valid identifiers.
+    config.parent = KEYWORD;
   }
 
   // concisely collects all tokens to be exported
@@ -50,8 +61,6 @@ createToken({
   pattern: /\/\*[^]*?\*\//,
   line_breaks: true
 });
-
-createToken({ name: 'KEYWORD', pattern: Lexer.NA, longer_alt: tokens.NAME });
 
 // Constants
 // Application constants

--- a/lib/dsl/poc/parser.js
+++ b/lib/dsl/poc/parser.js
@@ -21,7 +21,6 @@ class JDLParser extends Parser {
     $.RULE('prog', () => {
       $.MANY(() => {
         $.OR([
-          { ALT: () => $.SUBRULE($.constantDeclaration) },
           { ALT: () => $.SUBRULE($.entityDeclaration) },
           { ALT: () => $.SUBRULE($.relationDecl) },
           { ALT: () => $.SUBRULE($.enumDecl) },
@@ -35,7 +34,11 @@ class JDLParser extends Parser {
           { ALT: () => $.SUBRULE($.noServerDecl) },
           { ALT: () => $.SUBRULE($.angularSuffixDecl) },
           { ALT: () => $.SUBRULE($.noFluentMethod) },
-          { ALT: () => $.SUBRULE($.filterDecl) }
+          { ALT: () => $.SUBRULE($.filterDecl) },
+          // a constantDeclaration starts with a NAME, but a keyword may also be a NAME
+          // So to avoid conflicts with most of the above alternatives (which start with keywords)
+          // this alternative must be last.
+          { ALT: () => $.SUBRULE($.constantDeclaration) },
         ]);
       });
     });
@@ -199,9 +202,10 @@ class JDLParser extends Parser {
       });
 
       $.OR([
-        { ALT: () => { $.CONSUME2(t.NAME); } },
-        { ALT: () => { $.CONSUME(t.STAR); } },
         { ALT: () => { $.CONSUME(t.ALL); } },
+        { ALT: () => { $.CONSUME(t.STAR); } },
+        // NAME appears after 'ALL' token as an 'ALL' token is also a valid 'NAME'.
+        { ALT: () => { $.CONSUME2(t.NAME); } },
       ]);
 
       $.CONSUME(t.WITH);
@@ -304,9 +308,10 @@ class JDLParser extends Parser {
         // Chevrotain Docs: If you want to better distinguish between the Parse Trees of
         // the "t.NAME" used in this rule see "IN-LINED RULES"
         // https://github.com/SAP/chevrotain/blob/master/docs/concrete_syntax_tree.md#in-lined-rules
-        { ALT: () => { $.CONSUME2(t.NAME); } },
-        { ALT: () => { $.CONSUME(t.STAR); } },
         { ALT: () => { $.CONSUME(t.ALL); } },
+        { ALT: () => { $.CONSUME(t.STAR); } },
+        // NAME appears after 'ALL' token as an 'ALL' token is also a valid 'NAME'.
+        { ALT: () => { $.CONSUME2(t.NAME); } }
       ]);
     });
 

--- a/test/spec/grammar/parser_test.js
+++ b/test/spec/grammar/parser_test.js
@@ -10,11 +10,11 @@ describe('ChevrotainParser', () => {
       describe('with a default start rule', () => {
         it('parses a valid JDL text', () => {
           const input = `
-       entity JobHistory {
-         startDate ZonedDateTime,
-         endDate ZonedDateTime,
-         language Language
-       }`;
+           entity JobHistory {
+              startDate ZonedDateTime,
+              endDate ZonedDateTime,
+              language Language
+           }`;
 
           // debug and step into this to experience debugging the parser's code directly without
           // the abstraction of a 10,000 lines of generated source code in the way.
@@ -30,14 +30,26 @@ describe('ChevrotainParser', () => {
           expect(cst.children.entityDeclaration[0].children.NAME[0].image).to.equal('JobHistory');
           // ...
         });
+
+        it.only('parses a valid JDL text where keywords are used as an identifier', () => {
+          const input = `
+            entity entity {
+              startDate application,
+              enum filter
+            }`;
+
+          const result = parse(input);
+          expect(result.parseErrors).to.be.empty;
+        });
       });
       describe('with a custom start rule', () => {
         it('parses a valid JDL text using a custom startRule', () => {
-          const input = `{
-        startDate ZonedDateTime,
-        endDate ZonedDateTime,
-        language Language
-      }`;
+          const input = `
+            {
+              startDate ZonedDateTime,
+              endDate ZonedDateTime,
+              language Language
+            }`;
 
           const result = parse(input, 'entityBody');
           expect(result.parseErrors).to.be.empty;
@@ -54,10 +66,9 @@ describe('ChevrotainParser', () => {
       describe('with a single syntax error', () => {
         it('reports it', () => {
           const input = `
-        myConst1 = 1
-        myConst2 = 3, /* comma should not be here */
-        myConst3 = 9
-      `;
+            myConst1 = 1
+            myConst2 = 3, /* comma should not be here */
+            myConst3 = 9`;
           const result = parse(input);
           expect(result.parseErrors).to.have.lengthOf(1);
           expect(result.parseErrors[0].message).to.equal('Expecting token of type --> EOF <-- but found --> \',\' <--');
@@ -77,10 +88,9 @@ describe('ChevrotainParser', () => {
       describe('with multiple syntax errors', () => {
         it('reports them', () => {
           const input = `
-        myConst1 = 1
-        myConst2 = 3, /* <-- comma should not be here */
-        myConst3  9
-      `;
+            myConst1 = 1
+            myConst2 = 3, /* <-- comma should not be here */
+            myConst3  9`;
 
           const result = parse(input);
           expect(result.parseErrors).to.have.lengthOf(2);
@@ -105,10 +115,10 @@ describe('ChevrotainParser', () => {
         it('partially recovers from them', () => {
           it('Can report and PARTIALLY recover from syntax errors', () => {
             const input = `
-        myConst1 = 1
-        myConst2 = = = = = /* <- too many equal signs*/ 3, 
-        myConst3 /= 9
-      `;
+              myConst1 = 1
+              myConst2 = = = = = /* <- too many equal signs*/ 3, 
+              myConst3 /= 9
+            `;
 
             const result = parse(input);
             expect(result.parseErrors).to.have.lengthOf(1);
@@ -171,8 +181,8 @@ describe('ChevrotainParser', () => {
       describe('with a default start rule', () => {
         it('provides suggestions', () => {
           const input = `
-      entity person {
-        lastName string `;
+            entity person {
+            lastName string `;
 
           const result = getSyntacticAutoCompleteSuggestions(input);
           expect(result).to.have.lengthOf(5);


### PR DESCRIPTION
at the syntactic analysis level (pure parsing).

To the best of my understanding this is compatiable
with how the pegjs parser worked.

This does not mean that "entity enum {...}" is valid.
Only that it will pass "pure" parsing and should fail
in the reserved words check. (reserved_words.js).