### PR TITLE
Compatibility test harness for parser migration.

### DIFF
--- a/test/spec/grammar/compatibility_test.js
+++ b/test/spec/grammar/compatibility_test.js
@@ -8,9 +8,9 @@ const _ = require('lodash');
 describe('Chevrotain Migration compatibility harness', () => {
   describe('Can Parse all the existing JDL samples in the test folder', () => {
     const samplesDir = path.resolve(__dirname, '../../test_files/');
-    const jdlSamples = _.filter(fs.readdirSync(samplesDir), file => _.endsWith(file, '.jdl'));
+    const jdlSamples = fs.readdirSync(samplesDir).filter(file => _.endsWith(file, '.jdl'));
 
-    _.forEach(jdlSamples, (currSample) => {
+    jdlSamples.forEach((currSample) => {
       // uncomment the "skip" to run the compatibility tests locally.
       it.skip(`Sample: '${currSample}'`, () => {
         const sampleText = fs.readFileSync(path.resolve(__dirname, `../../test_files/${currSample}`), 'utf8');

--- a/test/spec/grammar/compatibility_test.js
+++ b/test/spec/grammar/compatibility_test.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-new, no-unused-expressions */
+const expect = require('chai').expect;
+const parse = require('../../../lib/dsl/poc/api').parse;
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+
+describe('Chevrotain Migration compatibility harness', () => {
+  describe('Can Parse all the existing JDL samples in the test folder', () => {
+    const samplesDir = path.resolve(__dirname, '../../test_files/');
+    const jdlSamples = _.filter(fs.readdirSync(samplesDir), file => _.endsWith(file, '.jdl'));
+
+    _.forEach(jdlSamples, (currSample) => {
+      // uncomment the "skip" to run the compatibility tests locally.
+      it.skip(`Sample: '${currSample}'`, () => {
+        const sampleText = fs.readFileSync(path.resolve(__dirname, `../../test_files/${currSample}`), 'utf8');
+        const parseResult = parse(sampleText);
+        expect(parseResult.parseErrors).to.be.empty;
+      });
+    });
+  });
+});


### PR DESCRIPTION
* It is skipped as it is meant to be run locally only.
* Allows checking syntax compatibility before the AST building is implemented.
* Currently 12/26 are failing, will examine those and will add commits to this PR.