### PR TITLE
WIP: Added reserved keywords for Kotlin

### DIFF
--- a/lib/core/jhipster/reserved_keywords.js
+++ b/lib/core/jhipster/reserved_keywords.js
@@ -61,6 +61,11 @@ const ReservedWords = {
     'EXTENDS', 'INT', 'SHORT', 'TRY', 'CHAR', 'FINAL', 'INTERFACE', 'STATIC', 'VOID', 'CLASS', 'FINALLY',
     'LONG', 'STRICTFP', 'VOLATILE', 'CONST', 'FLOAT', 'NATIVE', 'SUPER', 'WHILE'
   ],
+  KOTLIN: [
+    'AS', 'BREAK', 'CLASS', 'CONTINUE', 'DO', 'ELSE', 'FALSE', 'FOR', 'FUN', 'IF', 'IN', 'INTERFACE',
+    'IS', 'NULL', 'OBJECT', 'PACKAGE', 'RETURN', 'SUPER', 'THIS', 'THROW', 'TRUE', 'TRY', 'TYPEALIAS',
+    'VAL', 'VAR', 'WHEN', 'WHILE'
+  ],
   TYPESCRIPT: [
     'BREAK', 'CASE', 'CATCH', 'CLASS', 'CONST', 'CONSTRUCTOR', 'CONTINUE', 'DEBUGGER', 'DEFAULT', 'DELETE',
     'DO', 'ELSE', 'ENUM', 'EXPORT', 'EXTENDS', 'FALSE', 'FINALLY', 'FOR', 'FUNCTION', 'IF', 'IMPORT', 'IN',
@@ -197,7 +202,7 @@ function isReserved(keyword, type) {
 
 function isReservedClassName(keyword) {
   return isReserved(keyword, 'JHIPSTER') || isReserved(keyword, 'ANGULAR')
-    || isReserved(keyword, 'TYPESCRIPT') || isReserved(keyword, 'JAVA');
+    || isReserved(keyword, 'TYPESCRIPT') || isReserved(keyword, 'JAVA') || isReserved(keyword, 'KOTLIN');
 }
 
 function isReservedTableName(keyword, databaseType) {
@@ -207,7 +212,7 @@ function isReservedTableName(keyword, databaseType) {
 }
 
 function isReservedFieldName(keyword) {
-  return isReserved(keyword, 'ANGULAR') || isReserved(keyword, 'TYPESCRIPT') || isReserved(keyword, 'JAVA');
+  return isReserved(keyword, 'ANGULAR') || isReserved(keyword, 'TYPESCRIPT') || isReserved(keyword, 'JAVA') || isReserved(keyword, 'KOTLIN');
 }
 
 module.exports = {
@@ -218,6 +223,7 @@ module.exports = {
   JHIPSTER: ReservedWords.JHIPSTER,
   ANGULAR: ReservedWords.ANGULAR,
   JAVA: ReservedWords.JAVA,
+  KOTLIN: ReservedWords.KOTLIN,
   TYPESCRIPT: ReservedWords.TYPESCRIPT,
   MYSQL: ReservedWords.MYSQL,
   POSTGRESQL: ReservedWords.POSTGRESQL,

--- a/test/spec/core/jhipster/reserved_keywords_test.js
+++ b/test/spec/core/jhipster/reserved_keywords_test.js
@@ -34,9 +34,10 @@ describe('ReservedKeywords', () => {
       it('returns false', () => {
         expect(ReservedKeywords.isReserved('ValidKeyword', 'JHIPSTER')).to.be.false;
         expect(ReservedKeywords.isReserved('ACCOUNT', 'JAVA')).to.be.false;
+        expect(ReservedKeywords.isReserved('SUPER', 'KOTLIN')).to.be.false;
       });
     });
-    context('when passing an invalid jhipster keyword, no matter the case', () => {
+    context('when passing a valid jhipster keyword, no matter the case', () => {
       it('returns true', () => {
         expect(ReservedKeywords.isReserved('Account', 'JHIPSTER')).to.be.true;
         expect(ReservedKeywords.isReserved('account', 'jhipster')).to.be.true;
@@ -44,10 +45,11 @@ describe('ReservedKeywords', () => {
         expect(ReservedKeywords.isReserved('ACCOUNT', 'jhipster')).to.be.true;
       });
     });
-    context('when passing an invalid keyword for different types', () => {
+    context('when passing a valid keyword for different types', () => {
       it('returns true', () => {
         expect(ReservedKeywords.isReserved('ACCOUNT', 'jhipster')).to.be.true;
         expect(ReservedKeywords.isReserved('SUPER', 'JAVA')).to.be.true;
+        expect(ReservedKeywords.isReserved('FUN', 'KOTLIN')).to.be.true;
         expect(ReservedKeywords.isReserved('ACCESSIBLE', 'MYSQL')).to.be.true;
         expect(ReservedKeywords.isReserved('ANALYSE', 'POSTGRESQL')).to.be.true;
         expect(ReservedKeywords.isReserved('ADD', 'CASSANDRA')).to.be.true;
@@ -72,16 +74,17 @@ describe('ReservedKeywords', () => {
     });
   });
   describe('::isReservedFieldName', () => {
-    context('when passing a valid field name', () => {
+    context('when passing an invalid field name', () => {
       it('returns false', () => {
         expect(ReservedKeywords.isReservedFieldName('item')).to.be.false;
         expect(ReservedKeywords.isReservedFieldName('mySuperField')).to.be.false;
       });
     });
-    context('when passing an invalid field name', () => {
+    context('when passing a valid field name', () => {
       it('returns true', () => {
         expect(ReservedKeywords.isReservedFieldName('private')).to.be.true;
         expect(ReservedKeywords.isReservedFieldName('class')).to.be.true;
+        expect(ReservedKeywords.isReservedFieldName('fun')).to.be.true;
       });
     });
   });


### PR DESCRIPTION
Hello, 

while working on migrating the [`spring-controller`](https://github.com/jhipster/jhipster-kotlin/pull/16) for Kotlin, I noticed [this](https://github.com/thodorisbais/jhipster-kotlin/blob/985124019545d12d53cc324d96faba3ac36612f9/generators/spring-controller/prompts.js#L45) line and thought about enhancing the reserved keywords list by also adding Kotlin related references.

If you are fine with that, the convention used here is only about the Hard keywords Kotlin docs define.

Furthermore, there is something going wrong [here](https://github.com/thodorisbais/jhipster-core/blob/cfa2e8eca763664f3fb601eb81c84edd24f164ad/test/spec/core/jhipster/reserved_keywords_test.js#L87). 

If I understand correctly, the above test should pass.

Being in the need of feedback, I prefix this PR with a `WIP`.

Regards,
TB