### PR TITLE
100% coverage for ast_builder.js

### DIFF
--- a/lib/dsl/ast_builder.js
+++ b/lib/dsl/ast_builder.js
@@ -251,6 +251,7 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       return 'many-to-many';
     }
 
+    /* istanbul ignore next */
     throw new Error('Non exhaustive match');
   }
 
@@ -314,9 +315,7 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       entityList.push('*');
     }
 
-    if (ctx.Method) {
-      entityList.push(ctx.Method[0].image);
-    }
+    entityList.push(ctx.Method[0].image);
 
     // TODO: none unique elements should probably, be shown as warnings
     //       in a post parsing validation step instead of being transparently ignored
@@ -422,17 +421,13 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
         this
       );
       configProps.forEach((configProp) => {
-        config[configProp.key] = configProp.value;
+        // The pegjs parser only kept the first value of an occurrence of a config key.
+        // We are going to do the same...
+        if (!_.has(config, configProp.key)) {
+          config[configProp.key] = configProp.value;
 
-        if (configProp.key === 'packageName') {
-          config.packageFolder = configProp.value.replace(/[.]/g, '/');
-        }
-
-        if (configProp.key === 'serviceDiscoveryType') {
-          if (configProp.value === 'true') {
-            config.serviceDiscoveryType = true;
-          } else if (configProp.value === 'false') {
-            config.serviceDiscoveryType = false;
+          if (configProp.key === 'packageName') {
+            config.packageFolder = configProp.value.replace(/[.]/g, '/');
           }
         }
       });
@@ -450,12 +445,7 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
   }
 
   applicationConfigDeclaration(ctx) {
-    let key = ctx.CONFIG_KEY[0].image;
-
-    // https://github.com/jhipster/jhipster-core/issues/184#issuecomment-370972666
-    if (key === 'frontEndBuilder') {
-      key = 'frontendBuilder';
-    }
+    const key = ctx.CONFIG_KEY[0].image;
     const value = this.visit(ctx.configValue);
 
     return { key, value };
@@ -475,6 +465,7 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
       return ctx.BOOLEAN[0].image === 'true';
     }
 
+    /* istanbul ignore next */
     throw new Error('Non-Exhaustive Match');
   }
 

--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -187,6 +187,15 @@ class JDLSyntaxValidatorVisitor extends BaseJDLCSTVisitorWithDefaults {
   }
 
   checkIsSingleName(fqnCstNode) {
+    // A Boolean is allowed as a single name as it is a keyword.
+    // Other keywords do not need special handling as they do not explicitly appear in the rule
+    // of config values
+    if (fqnCstNode.tokenType && _.includes(fqnCstNode.tokenType.CATEGORIES, t.BOOLEAN)) {
+      // TODO: this is a little hacky, we are returning false to avoid farther checks
+      // on "Boolean as names". Can we do this in a cleaner manner?
+      return false;
+    }
+
     const dots = fqnCstNode.children.DOT;
     if (dots && dots.length >= 1) {
       this.errors.push({
@@ -201,7 +210,9 @@ class JDLSyntaxValidatorVisitor extends BaseJDLCSTVisitorWithDefaults {
   checkExpectedValueType(expected, actual) {
     switch (expected) {
     case 'NAME':
-      if (actual.name !== 'qualifiedName') {
+      if (actual.name !== 'qualifiedName' &&
+          // a Boolean (true/false) is also a valid name.
+          (actual.tokenType && !_.includes(actual.tokenType.CATEGORIES, t.BOOLEAN))) {
         this.errors.push({
           message: `A name is expected, but found: "${
             getFirstToken(actual).image
@@ -390,7 +401,8 @@ class JDLSyntaxValidatorVisitor extends BaseJDLCSTVisitorWithDefaults {
 }
 
 function trimAnchors(str) {
-  return str.replace(/^\^/, '').replace(/\$$/, '');
+  return str.replace(/^\^/, '')
+    .replace(/\$$/, '');
 }
 
 function getFirstToken(tokOrCstNode) {
@@ -399,9 +411,10 @@ function getFirstToken(tokOrCstNode) {
   }
 
   // CST Node - - assumes no nested CST Nodes, only terminals
-  return _.flatten(_.values(tokOrCstNode.children)).reduce(
-    (firstTok, nextTok) =>
-      (firstTok.startOffset > nextTok.startOffset ? nextTok : firstTok),
-    { startOffset: Infinity }
-  );
+  return _.flatten(_.values(tokOrCstNode.children))
+    .reduce(
+      (firstTok, nextTok) =>
+        (firstTok.startOffset > nextTok.startOffset ? nextTok : firstTok),
+      { startOffset: Infinity }
+    );
 }

--- a/test/test_files/random_snippets.jdl
+++ b/test/test_files/random_snippets.jdl
@@ -1,16 +1,37 @@
 // used in comparability testing of old vs new parser.
 
+// Test behavior of pegjs and chevrotain parsers in regard to duplicate
+// keys in the AST ("Foo") is used as the key in the angularSuffix dictionary.
 angularSuffix all with Foo except Bar
+angularSuffix all with Foo except Bar2
+
+// empty application
+application {
+
+}
+
+// empty application with empty config
+application {
+  config {
+
+  }
+}
 
 entity Job {
   jobTitle String pattern (/manager|supremeLeader/)
 }
 
-service Employee with serviceClass except Foo
-
 microservice A with ms except Foo
 search A with ms except Foo
 skipClient all except Foo
+
+application {
+  config {
+    /* pegjs parser only kept the first value of the same config key*/
+    serviceDiscoveryType false
+    serviceDiscoveryType true
+  }
+}
 
 
 /**


### PR DESCRIPTION
Resolved some edge cases:
- Boolean as "IDENTIFER" value for application config key.
- Which value gets picked with multiple (same) config keys for application.

And removed some unneeded handling of non existant edge cases.
