### PR TITLE
Regenerate entity if jpaMetamodelFiltering attribute has changed

### DIFF
--- a/lib/utils/object_utils.js
+++ b/lib/utils/object_utils.js
@@ -99,7 +99,9 @@ function areRelationshipsEqual(firstRelationships, secondRelationships) {
   });
 }
 
-function areOptionsTheSame(firstEntity, secondEntity) {
+function areOptionsTheSame(currentEntity, entityToGenerate) {
   return firstEntity.dto === secondEntity.dto && firstEntity.pagination === secondEntity.pagination
-    && firstEntity.service === secondEntity.service && firstEntity.searchEngine === secondEntity.searchEngine;
+    && firstEntity.service === secondEntity.service && firstEntity.searchEngine === secondEntity.searchEngine
+    // If jpaMetamodelFiltering is omitted it is regarded as false to prevent useless regeneration
+    && (!!currentEntity.jpaMetamodelFiltering === entityToGenerate.jpaMetamodelFiltering);
 }

--- a/lib/utils/object_utils.js
+++ b/lib/utils/object_utils.js
@@ -100,8 +100,8 @@ function areRelationshipsEqual(firstRelationships, secondRelationships) {
 }
 
 function areOptionsTheSame(currentEntity, entityToGenerate) {
-  return firstEntity.dto === secondEntity.dto && firstEntity.pagination === secondEntity.pagination
-    && firstEntity.service === secondEntity.service && firstEntity.searchEngine === secondEntity.searchEngine
+  return currentEntity.dto === entityToGenerate.dto && currentEntity.pagination === entityToGenerate.pagination
+    && currentEntity.service === entityToGenerate.service && currentEntity.searchEngine === entityToGenerate.searchEngine
     // If jpaMetamodelFiltering is omitted it is regarded as false to prevent useless regeneration
     && (!!currentEntity.jpaMetamodelFiltering === entityToGenerate.jpaMetamodelFiltering);
 }


### PR DESCRIPTION
import-jdl should regenerate entities with changed jpaMetamodelFiltering option

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [ ] Tests are added where necessary
  - [X] Documentation is added/updated where necessary
  - [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
