### PR TITLE
set searchEngine to false when element is excluded in JDL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ jhipster-jdl.jh
 coverage/*
 sonar-project.properties
 .nyc_output/*
+jhipster-core.iml

--- a/lib/parser/entity_parser.js
+++ b/lib/parser/entity_parser.js
@@ -164,6 +164,14 @@ function setEntityNamesOptions(option) {
       entities[entityName][option.name] = option.value;
     }
   });
+  option.excludedNames.forEach((entityName) => {
+    switch (option.name) {
+    case BinaryOptions.SEARCH_ENGINE:
+      entities[entityName].searchEngine = false;
+      break;
+    default:
+    }
+  });
 }
 
 function addServiceIfNeedBe(entityName) {

--- a/test/spec/parser/entity_parser_test.js
+++ b/test/spec/parser/entity_parser_test.js
@@ -619,6 +619,32 @@ describe('EntityParser', () => {
           );
         });
       });
+      context('when converting a JDL with elastic except', () => {
+        let content = null;
+
+        before(() => {
+          const entityA = new JDLEntity({ name: 'A' });
+          const entityB = new JDLEntity({ name: 'B' });
+          const option = new JDLBinaryOption({
+            name: BinaryOptions.SEARCH_ENGINE,
+            value: 'elasticsearch',
+            excludedNames: ['B']
+          });
+          const jdlObject = new JDLObject();
+          jdlObject.addEntity(entityA);
+          jdlObject.addEntity(entityB);
+          jdlObject.addOption(option);
+          content = EntityParser.parse({
+            jdlObject,
+            databaseType: DatabaseTypes.SQL
+          });
+        });
+
+        it('converts it', () => {
+          expect(content.A.searchEngine).to.equal('elasticsearch');
+          expect(content.B.searchEngine).to.be.false;
+        });
+      });
       context('when converting a JDL with filtering', () => {
         context('if there was not a service option for entity', () => {
           let content = null;


### PR DESCRIPTION
This PR is a prerequisite to add variability with elasticsearch (when the option is set to false, the generator won't generate elastic classes).

PR completing this one will come in the generator-jhipster soon (Work on my machine)!

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
