### PR TITLE
fix default injected fields when not specified

### DIFF
--- a/lib/parser/document_parser.js
+++ b/lib/parser/document_parser.js
@@ -215,7 +215,8 @@ function fillAssociations() {
   for (let i = 0; i < configuration.document.relationships.length; i++) {
     const relationship = configuration.document.relationships[i];
     if (!relationship.from.injectedField && !relationship.to.injectedField) {
-      relationship.from.injectedField = _.lowerFirst(relationship.from.name);
+      relationship.from.injectedField = _.lowerFirst(relationship.to.name);
+      relationship.to.injectedField = _.lowerFirst(relationship.from.name);
     }
     jdlObject.addRelationship(new JDLRelationship({
       from: jdlObject.getEntity(relationship.from.name),

--- a/test/spec/parser/document_parser_test.js
+++ b/test/spec/parser/document_parser_test.js
@@ -789,7 +789,9 @@ describe('DocumentParser', () => {
       });
       context('when parsing a relationship with no injected field', () => {
         let jdlObject = null;
-        let relationship = null;
+        let relationshipOneToOne = null;
+        let relationshipOneToMany = null;
+        let relationshipManyToMany = null;
 
         before(() => {
           const input = JDLReader.parseFromFiles(['./test/test_files/no_injected_field.jdl']);
@@ -797,11 +799,18 @@ describe('DocumentParser', () => {
             document: input,
             applicationType: ApplicationTypes.MONOLITH
           });
-          relationship = jdlObject.relationships.getOneToOne('OneToOne_A{a}_B');
+          relationshipOneToOne = jdlObject.relationships.getOneToOne('OneToOne_A{b}_B{a}');
+          relationshipOneToMany = jdlObject.relationships.getOneToMany('OneToMany_A{b}_B{a}');
+          relationshipManyToMany = jdlObject.relationships.getManyToMany('ManyToMany_A{b}_B{a}');
         });
 
         it('adds a default one', () => {
-          expect(relationship.injectedFieldInFrom).to.equal('a');
+          expect(relationshipOneToOne.injectedFieldInTo).to.equal('a');
+          expect(relationshipOneToOne.injectedFieldInFrom).to.equal('b');
+          expect(relationshipOneToMany.injectedFieldInTo).to.equal('a');
+          expect(relationshipOneToMany.injectedFieldInFrom).to.equal('b');
+          expect(relationshipManyToMany.injectedFieldInTo).to.equal('a');
+          expect(relationshipManyToMany.injectedFieldInFrom).to.equal('b');
         });
       });
       context('when parsing entities with annotations', () => {

--- a/test/test_files/no_injected_field.jdl
+++ b/test/test_files/no_injected_field.jdl
@@ -4,3 +4,11 @@ entity B
 relationship OneToOne {
   A to B
 }
+
+relationship OneToMany {
+  A to B
+}
+
+relationship ManyToMany {
+  A to B
+}


### PR DESCRIPTION
Related to https://github.com/jhipster/jhipster-core/commit/f5eb79830ac81babdd90189deb67ba508018d82a
 - `relationshipName` should default to the other entity name (currently default to same entity name)
 - `otherEntityRelationshipName` should default to the entity name (currently default to blank for `ManyToMany`)
 - Fixes database setup for `ManyToMany` relationships (liquibase complained on duplicate key due to below issue)

The JDL:
```
entity A
entity B

relationship OneToOne {
  A to B
}

relationship OneToMany {
  A to B
}

relationship ManyToMany {
  A to B
}
```
used to result in A's relationships:
```
        {
            "relationshipType": "one-to-one",
            "relationshipName": "a",
            "otherEntityName": "b",
            "otherEntityField": "id",
            "ownerSide": true,
            "otherEntityRelationshipName": "a"
        },
        {
            "relationshipType": "one-to-many",
            "relationshipName": "a",
            "otherEntityName": "b",
            "otherEntityRelationshipName": "a"
        },
        {
            "relationshipType": "many-to-many",
            "otherEntityRelationshipName": "",
            "relationshipName": "a",
            "otherEntityName": "b",
            "otherEntityField": "id",
            "ownerSide": true
        }
```
now it correctly results in:
```
        {
            "relationshipType": "one-to-one",
            "relationshipName": "b",
            "otherEntityName": "b",
            "otherEntityField": "id",
            "ownerSide": true,
            "otherEntityRelationshipName": "a"
        },
        {
            "relationshipType": "one-to-many",
            "relationshipName": "b",
            "otherEntityName": "b",
            "otherEntityRelationshipName": "a"
        },
        {
            "relationshipType": "many-to-many",
            "otherEntityRelationshipName": "a",
            "relationshipName": "b",
            "otherEntityName": "b",
            "otherEntityField": "id",
            "ownerSide": true
        }
```
and it also now creates the relationship on the B side as well for `OneToOne` and `ManyToMany`

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [X] Tests are added where necessary
  - [X] Documentation is added/updated where necessary
  - [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
