### PR TITLE
match generator-jhipster methods for generating keys

### DIFF
--- a/lib/core/jdl_application.js
+++ b/lib/core/jdl_application.js
@@ -183,11 +183,11 @@ function fixApplicationConfig(passedConfig) {
 }
 
 function generateJWTSecretKey() {
-  return generateRememberMeKey();
+  return Buffer.from(crypto.randomBytes(50).toString('hex')).toString('base64');
 }
 
 function generateRememberMeKey() {
-  return crypto.randomBytes(20).toString('hex');
+  return crypto.randomBytes(50).toString('hex');
 }
 
 function stringifyConfig(applicationConfig) {

--- a/test/test_files/jhipster_app/.yo-rc.json
+++ b/test/test_files/jhipster_app/.yo-rc.json
@@ -15,7 +15,7 @@
     "searchEngine": false,
     "buildTool": "gradle",
     "enableSocialSignIn": false,
-    "rememberMeKey": "5f1100e7eae25e2abe32d7b2031ac1f2acc778d8",
+    "rememberMeKey": "MTBlZDY1OTk5Yjc2MjRkZDY3ZDkwZTE1ZWY1Nzg5MTQ0NWU0MjA4OTcxZDMyMTUzZTcxOGFhM2UwMWIyYjlkZmQ3OTljZTkwNThlYmViZDM0M2Y2OWFiM2JhNWY5ZDZkYzBhODg3ZDkwOGQyYmY1ZTFiYzFkNDhkNjhjZGFmNDE=",
     "useSass": false,
     "applicationType": "monolith",
     "testFrameworks": [],


### PR DESCRIPTION
Fixes JDL application generation for JWT apps, updates key to new JWT requirement of base64 encoding and 256 bits which aligns the code with [`generator-jhipster`](https://github.com/jhipster/generator-jhipster/blob/master/generators/server/prompts.js#L283-L289)

Related to https://github.com/jhipster/generator-jhipster/issues/8165

Steps to reproduce issue:
 - Use below JDL to generate app
 - Run `./mvnw` and app will fail due to invalid key length

```
application {
    config {
       searchEngine elasticsearch
    }
    entities Foo
}
entity Foo {
    fieldOne LocalDate
}
```

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
