### PR TITLE
JDL generator has wrong regex validation for language(can't pass zh-cn,zh-tw)

### DIFF
--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -33,6 +33,7 @@ const ALPHABETIC = /^[A-Za-z]+$/;
 const ALPHABETIC_LOWER = /^[a-z]+$/;
 const ALPHANUMERIC = /^[A-Za-z][A-Za-z0-9]*$/;
 const ALPHANUMERIC_DASH = /^[A-Za-z][A-Za-z0-9-]*$/;
+const LANGUAGE_PATTERN = /^[a-z]+(-[A-Za-z0-9]+)*$/;
 
 const configPropsValidations = {
   APPLICATION_TYPE: {
@@ -96,7 +97,7 @@ const configPropsValidations = {
   },
   LANGUAGES: {
     type: 'list',
-    pattern: ALPHABETIC_LOWER,
+    pattern: LANGUAGE_PATTERN,
     msg: 'languages property'
   },
   MESSAGE_BROKER: {
@@ -106,7 +107,7 @@ const configPropsValidations = {
   },
   NATIVE_LANGUAGE: {
     type: 'NAME',
-    pattern: ALPHABETIC_LOWER,
+    pattern: LANGUAGE_PATTERN,
     msg: 'nativeLanguage property'
   },
   PACKAGE_NAME: {

--- a/test/spec/grammar/validator_test.js
+++ b/test/spec/grammar/validator_test.js
@@ -727,7 +727,7 @@ describe('JDLSyntaxValidatorVisitor', () => {
             parse(`
             application {
               config {
-                languages [a,b, c]
+                languages [ab,bc, cd, zh-cn]
               }
             }`)
           ).to.not.throw();
@@ -862,7 +862,7 @@ describe('JDLSyntaxValidatorVisitor', () => {
                   nativeLanguage FOO
                 }
               }`)
-            ).to.throw('The nativeLanguage property name must match: /^[a-z]+$/');
+            ).to.throw('The nativeLanguage property name must match: /^[a-z]+(-[A-Za-z0-9]+)*$/');
           });
         });
 


### PR DESCRIPTION
The language regex can't contains dash character, we need to support that.
Accoridng to https://tools.ietf.org/html/rfc5646, some language code also
may contain number characters. 

=================

  676 passing (1s)

$ npm run coverage

> jhipster-core@3.3.2 coverage /home/bohong/workspace/jhipster-core
> nyc --reporter=text-summary report

=============================== Coverage summary ===============================
Statements   : 96.75% ( 2500/2584 )
Branches     : 93.05% ( 1125/1209 )
Functions    : 96.41% ( 671/696 )
Lines        : 96.82% ( 2470/2551 )
================================================================================
Done in 7.03s.

Please make sure the below checklist is followed for Pull Requests.
  - [✔️] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [✔️] Tests are added where necessary
  - [✔️] Documentation is added/updated where necessary
  - [✔️] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
