### PR TITLE
uaa apps require skipUserManagement to be false

### DIFF
--- a/lib/core/jdl_uaa_application.js
+++ b/lib/core/jdl_uaa_application.js
@@ -48,8 +48,8 @@ class JDLUaaApplication extends JDLApplication {
     if (config.skipServer) {
       delete config.skipServer;
     }
+    config.skipUserManagement = false;
     config.skipClient = true;
-    config.skipUserManagement = true;
     return config;
   }
 }

--- a/lib/exceptions/business_error_checker.js
+++ b/lib/exceptions/business_error_checker.js
@@ -78,9 +78,6 @@ class BusinessErrorChecker {
 
   checkForApplicationErrors() {
     this.jdlObject.forEachApplication(jdlApplication => {
-      if (jdlApplication.config.applicationType === ApplicationTypes.UAA && jdlApplication.config.skipUserManagement) {
-        throw new Error('Skipping user management in a UAA app is forbidden.');
-      }
       const applicationIsAMicroserviceWithoutOauth2 =
         jdlApplication.config.authenticationType !== 'oauth2' &&
         jdlApplication.config.applicationType === ApplicationTypes.MICROSERVICE;

--- a/test/spec/exceptions/business_error_checker_test.js
+++ b/test/spec/exceptions/business_error_checker_test.js
@@ -37,7 +37,6 @@ const JDLObject = require('../../../lib/core/jdl_object');
 const JDLGatewayApplication = require('../../../lib/core/jdl_gateway_application');
 const JDLMonolithApplication = require('../../../lib/core/jdl_monolith_application');
 const JDLMicroserviceApplication = require('../../../lib/core/jdl_microservice_application');
-const JDLUaaApplication = require('../../../lib/core/jdl_uaa_application');
 const JDLBinaryOption = require('../../../lib/core/jdl_binary_option');
 const JDLEntity = require('../../../lib/core/jdl_entity');
 const JDLEnum = require('../../../lib/core/jdl_enum');
@@ -150,25 +149,6 @@ describe('BusinessErrorChecker', () => {
       jdlObject = new JDLObject();
     });
 
-    context('when having an UAA application with skipped user management', () => {
-      before(() => {
-        jdlObject.addApplication(
-          new JDLUaaApplication({
-            config: {
-              skipUserManagement: true,
-              uaaBaseName: 'uaa'
-            }
-          })
-        );
-        checker = new BusinessErrorChecker(jdlObject);
-      });
-
-      it('fails', () => {
-        expect(() => {
-          checker.checkForApplicationErrors();
-        }).to.throw('Skipping user management in a UAA app is forbidden.');
-      });
-    });
     context('when having no database type', () => {
       context('for a microservice without oauth2', () => {
         before(() => {

--- a/test/test_files/uaa_with_user_management_skipped.jdl
+++ b/test/test_files/uaa_with_user_management_skipped.jdl
@@ -1,6 +1,0 @@
-application {
-  config {
-    applicationType uaa,
-    skipUserManagement true
-  }
-}


### PR DESCRIPTION
This is using the master branch for both `jhipster-core` and the generator.  In a UAA stack, the user management is in the UAA app so it can't skip it. Trying to generate a UAA fails with the following error:
```
/tmp/jh/jdlmstest » jh import-jdl ms.jdl
Using JHipster version installed globally
Executing import-jdl ms.jdl
Options: from-cli: true
The JDL is being parsed.
Error: Skipping user management in a UAA app is forbidden.
ERROR! Error while parsing applications and entities from the JDL Error: Skipping user management in a UAA app is forbidden.
```
JDL:
```

application {
  config {
    baseName uaabase
    applicationType uaa
  }
}
application {
  config {
    applicationType gateway
    uaaBaseName "uaabase"
    authenticationType uaa
  }
}
```

The other option is to delete the line and keep the tests and logic checks.

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [ ] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
