### PR TITLE
Add support for alphanumeric package names

### DIFF
--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -33,6 +33,7 @@ const ALPHABETIC = /^[A-Za-z]+$/;
 const ALPHABETIC_LOWER = /^[a-z]+$/;
 const ALPHANUMERIC = /^[A-Za-z][A-Za-z0-9]*$/;
 const ALPHANUMERIC_DASH = /^[A-Za-z][A-Za-z0-9-]*$/;
+const ALPHANUMERIC_LOWER = /^[a-z][a-z0-9]*$/;
 const LANGUAGE_PATTERN = /^[a-z]+(-[A-Za-z0-9]+)*$/;
 
 const configPropsValidations = {
@@ -112,7 +113,7 @@ const configPropsValidations = {
   },
   PACKAGE_NAME: {
     type: 'qualifiedName',
-    pattern: ALPHABETIC_LOWER,
+    pattern: ALPHANUMERIC_LOWER,
     msg: 'packageName property'
   },
   PROD_DATABASE_TYPE: {

--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -29,11 +29,11 @@ const ENUM_NAME_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
 const ENUM_PROP_NAME_PATTERN = /^[A-Z][A-Za-z0-9_]*$/;
 const METHOD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
 const JHI_PREFIX_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-_]*$/;
+const PACKAGE_NAME_PATTERN = /^[a-z_][a-z0-9_]*$/;
 const ALPHABETIC = /^[A-Za-z]+$/;
 const ALPHABETIC_LOWER = /^[a-z]+$/;
 const ALPHANUMERIC = /^[A-Za-z][A-Za-z0-9]*$/;
 const ALPHANUMERIC_DASH = /^[A-Za-z][A-Za-z0-9-]*$/;
-const ALPHANUMERIC_LOWER = /^[a-z][a-z0-9]*$/;
 const LANGUAGE_PATTERN = /^[a-z]+(-[A-Za-z0-9]+)*$/;
 
 const configPropsValidations = {
@@ -113,7 +113,7 @@ const configPropsValidations = {
   },
   PACKAGE_NAME: {
     type: 'qualifiedName',
-    pattern: ALPHANUMERIC_LOWER,
+    pattern: PACKAGE_NAME_PATTERN,
     msg: 'packageName property'
   },
   PROD_DATABASE_TYPE: {

--- a/test/spec/grammar/validator_test.js
+++ b/test/spec/grammar/validator_test.js
@@ -915,7 +915,7 @@ describe('JDLSyntaxValidatorVisitor', () => {
                   packageName FOO
                 }
               }`)
-            ).to.throw('The packageName property name must match: /^[a-z]+$/');
+            ).to.throw('The packageName property name must match: /^[a-z_][a-z0-9_]*$/');
           });
         });
       });


### PR DESCRIPTION
Example package names could now be microservice1, microservice2, etc.

Used 5.4.1 and the following JDL for testing:

```
application {
  config {
    baseName uaa,
    applicationType uaa,
    packageName com.example.uaa,
    authenticationType uaa,
    uaaBaseName "uaa",
    prodDatabaseType postgresql,
    serviceDiscoveryType eureka,
    buildTool gradle
  }
}

application {
  config {
    baseName gateway,
    applicationType gateway,
    authenticationType uaa,
    packageName com.example.gateway,
    uaaBaseName "uaa",
    databaseType no,
    serviceDiscoveryType eureka,
    clientFramework react,
    buildTool gradle
  }
  entities A, B, C, D
}

application {
  config {
    baseName microservice1,
    applicationType microservice,
    authenticationType uaa,
    packageName com.example.microservice1,
    uaaBaseName "uaa",
    prodDatabaseType postgresql,
    serviceDiscoveryType eureka,
    buildTool gradle
  }
  entities A, B
}

application {
  config {
    baseName microservice2,
    applicationType microservice,
    packageName com.example.microservice2,
    authenticationType uaa,
    uaaBaseName "uaa",
    prodDatabaseType postgresql,
    serviceDiscoveryType eureka,
    buildTool gradle
  }
  entities C, D
}

entity A {
    data String
}

entity B {
    data String
}

entity C {
    data String
}

entity D {
    data String
}

dto * with mapstruct
service * with serviceClass

microservice A, B with microservice1
microservice C, D with microservice2
```

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [] Tests are added where necessary
  - [X] Documentation is added/updated where necessary
  - [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
