### PR TITLE
Update to not force skipUserManagement for uaa gateway

### DIFF
--- a/lib/core/jdl_gateway_application.js
+++ b/lib/core/jdl_gateway_application.js
@@ -34,10 +34,7 @@ class JDLGatewayApplication extends AbstractJDLApplication {
     if (!this.config.serverPort) {
       this.config.serverPort = ApplicationOptions.serverPort;
     }
-    if (
-      this.config.authenticationType === ApplicationOptions.authenticationType.uaa ||
-      this.config.authenticationType === ApplicationOptions.authenticationType.oauth2
-    ) {
+    if (this.config.authenticationType === ApplicationOptions.authenticationType.oauth2) {
       this.config.skipUserManagement = true;
     }
     if (!this.config.clientFramework) {

--- a/test/spec/core/jdl_gateway_application_test.js
+++ b/test/spec/core/jdl_gateway_application_test.js
@@ -64,20 +64,6 @@ describe('JDLGatewayApplication', () => {
         expect(jdlApplicationConfig.useSass).to.be.true;
       });
     });
-    context(`when the authentication type is ${ApplicationOptions.authenticationType.uaa}`, () => {
-      let jdlApplicationConfig = null;
-
-      before(() => {
-        const jdlApplication = new JDLGatewayApplication({
-          config: { authenticationType: ApplicationOptions.authenticationType.uaa, jhipsterVersion: '4.9.0' }
-        });
-        jdlApplicationConfig = jdlApplication.config;
-      });
-
-      it('sets the skipUserManagement flag to true', () => {
-        expect(jdlApplicationConfig.skipUserManagement).to.be.true;
-      });
-    });
     context(`when the authentication type is ${ApplicationOptions.authenticationType.oauth2}`, () => {
       let jdlApplicationConfig = null;
 


### PR DESCRIPTION
When using a uaa gateway, skipUserManagement should not be forced to true. The gateway still needs to generate the user management client code.

This is to fix this issue: https://github.com/jhipster/jhipster-core/issues/268

Please make sure the below checklist is followed for Pull Requests.
  - [X] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [X] Tests are added where necessary
  - [X] Documentation is added/updated where necessary
  - [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
