### PR TITLE
Validate applicationType and authenticationType for valid values

### DIFF
--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -29,6 +29,8 @@ const ENUM_NAME_PATTERN = /^[A-Z][A-Za-z0-9]*$/;
 const ENUM_PROP_NAME_PATTERN = /^[A-Z][A-Za-z0-9_]*$/;
 const METHOD_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
 const JHI_PREFIX_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9-_]*$/;
+const APPLICATION_TYPE_PATTERN = /^(monolith|microservice|gateway|uaa)$/;
+const AUTHENTICATION_TYPE_PATTERN = /^(jwt|session|uaa|oauth2)$/;
 const PACKAGE_NAME_PATTERN = /^[a-z_][a-z0-9_]*$/;
 const ALPHABETIC = /^[A-Za-z]+$/;
 const ALPHABETIC_LOWER = /^[a-z]+$/;
@@ -39,12 +41,12 @@ const LANGUAGE_PATTERN = /^[a-z]+(-[A-Za-z0-9]+)*$/;
 const configPropsValidations = {
   APPLICATION_TYPE: {
     type: 'NAME',
-    pattern: ALPHABETIC_LOWER,
+    pattern: APPLICATION_TYPE_PATTERN,
     msg: 'applicationType property'
   },
   AUTHENTICATION_TYPE: {
     type: 'NAME',
-    pattern: ALPHANUMERIC,
+    pattern: AUTHENTICATION_TYPE_PATTERN,
     msg: 'authenticationType property'
   },
   BASE_NAME: {

--- a/test/spec/grammar/validator_test.js
+++ b/test/spec/grammar/validator_test.js
@@ -29,114 +29,51 @@ describe('JDLSyntaxValidatorVisitor', () => {
             parse(`
             application {
               config {
-                applicationType foo
+                applicationType gateway
               }
             }`)
           ).to.not.throw();
         });
       });
       context('an invalid value', () => {
-        context('such as a number', () => {
+        context('such as GATEWAY', () => {
           it('will report a syntax error', () => {
             expect(() =>
               parse(`
               application {
                 config {
-                  applicationType 666
+                  applicationType GATEWAY
                 }
               }`)
-            ).to.throw('A name is expected, but found: "666"');
-          });
-        });
-        context('such as an invalid character', () => {
-          it('will report a syntax error', () => {
-            expect(() =>
-              parse(`
-              application {
-                config {
-                  applicationType -
-                }
-              }`)
-            ).to.throw('unexpected character: ->-<-');
-          });
-        });
-        context('such as a capitalized letters', () => {
-          it('will report a syntax error', () => {
-            expect(() =>
-              parse(`
-              application {
-                config {
-                  applicationType FOO
-                }
-              }`)
-            ).to.throw('The applicationType property name must match: /^[a-z]+$/');
-          });
-        });
-
-        context('having illegal characters', () => {
-          it('will report a syntax error', () => {
-            expect(() =>
-              parse(`
-              application {
-                config {
-                  applicationType foo.bar
-                }
-              }`)
-            ).to.throw('A single name is expected, but found a fully qualified name');
+            ).to.throw('The applicationType property name must match: /^(monolith|microservice|gateway|uaa)$/');
           });
         });
       });
     });
     context('and using for authenticationType', () => {
       context('a valid value', () => {
-        context('with only letters', () => {
-          it('does not report a syntax error', () => {
-            expect(() =>
-              parse(`
+        it('does not report a syntax error for name', () => {
+          expect(() =>
+            parse(`
             application {
               config {
                 authenticationType jwt
               }
             }`)
-            ).to.not.throw();
-          });
-        });
-        context('with both letters and numbers', () => {
-          it('does not report a syntax error', () => {
-            expect(() =>
-              parse(`
-            application {
-              config {
-                authenticationType jwt42
-              }
-            }`)
-            ).to.not.throw();
-          });
+          ).to.not.throw();
         });
       });
       context('an invalid value', () => {
-        context('such as quotes', () => {
-          it('fails', () => {
+        context('such as JWT', () => {
+          it('will report a syntax error', () => {
             expect(() =>
               parse(`
-            application {
-              config {
-                authenticationType "jwt"
-              }
-            }`)
-            ).to.throw('A name is expected, but found: ""jwt""');
-          });
-        });
-        context('such as numbers', () => {
-          it('fails', () => {
-            expect(() =>
-              parse(`
-            application {
-              config {
-                authenticationType 42
-              }
-            }`)
-            ).to.throw('A name is expected, but found: "42"');
+              application {
+                config {
+                  authenticationType JWT
+                }
+              }`)
+            ).to.throw('The authenticationType property name must match: /^(jwt|session|uaa|oauth2)$/');
           });
         });
       });


### PR DESCRIPTION
I spent a while researching "what I thought was a bug" because I had `authenticationType` in my JDL set to `JWT` and not `jwt`.

I updated the validators to match what values are listed at https://www.jhipster.tech/jdl/  for `applicationType` and `authenticationType`.

Please make sure the below checklist is followed for Pull Requests.
  - [] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [X] Tests are added where necessary
  - [X] Documentation is added/updated where necessary
  - [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
