### PR TITLE
Allow relationships from the User entity if skipUserManagement is set

### DIFF
--- a/lib/exceptions/business_error_checker.js
+++ b/lib/exceptions/business_error_checker.js
@@ -21,6 +21,7 @@ const logger = require('../utils/objects/logger');
 const { checkApplication } = require('./application_validator');
 const { checkOptions } = require('./option_validator');
 const { GATEWAY } = require('../core/jhipster/application_types');
+const { SKIP_USER_MANAGEMENT } = require('../core/jhipster/unary_options');
 const FieldTypes = require('../core/jhipster/field_types');
 const { isReservedClassName, isReservedFieldName, isReservedTableName } = require('../core/jhipster/reserved_keywords');
 
@@ -144,7 +145,8 @@ class BusinessErrorChecker {
     this.jdlObject.forEachRelationship(jdlRelationship => {
       const absentEntities = [];
 
-      if (jdlRelationship.from.toLowerCase() === USER.toLowerCase()) {
+      const skipUserManagement = this.jdlObject.getOptionsForName(SKIP_USER_MANAGEMENT)[0];
+      if (jdlRelationship.from.toLowerCase() === USER.toLowerCase() && !skipUserManagement) {
         throw new Error(
           `Relationships from the User entity is not supported in the declaration between '${
             jdlRelationship.from
@@ -163,7 +165,10 @@ class BusinessErrorChecker {
       if (!this.jdlObject.getEntity(jdlRelationship.from)) {
         absentEntities.push(jdlRelationship.from);
       }
-      if (jdlRelationship.to.toLowerCase() !== USER.toLowerCase() && !this.jdlObject.getEntity(jdlRelationship.to)) {
+      if (
+        !this.jdlObject.getEntity(jdlRelationship.to) &&
+        (jdlRelationship.to.toLowerCase() !== USER.toLowerCase() || skipUserManagement)
+      ) {
         absentEntities.push(jdlRelationship.to);
       }
       if (absentEntities.length !== 0) {

--- a/test/spec/exceptions/business_error_checker_test.js
+++ b/test/spec/exceptions/business_error_checker_test.js
@@ -504,31 +504,64 @@ describe('BusinessErrorChecker', () => {
     });
 
     context('when having User as source entity', () => {
-      before(() => {
-        const userEntity = new JDLEntity({
-          name: 'User'
+      context('when skipUserManagement flag is not set', () => {
+        before(() => {
+          const userEntity = new JDLEntity({
+            name: 'User'
+          });
+          const otherEntity = new JDLEntity({
+            name: 'Valid'
+          });
+          const relationship = new JDLRelationship({
+            from: userEntity.name,
+            to: otherEntity.name,
+            type: RelationshipTypes.ONE_TO_ONE,
+            injectedFieldInFrom: 'other'
+          });
+          jdlObject.addEntity(userEntity);
+          jdlObject.addEntity(otherEntity);
+          jdlObject.addRelationship(relationship);
+          checker = new BusinessErrorChecker(jdlObject);
         });
-        const otherEntity = new JDLEntity({
-          name: 'Valid'
-        });
-        const relationship = new JDLRelationship({
-          from: userEntity.name,
-          to: otherEntity.name,
-          type: RelationshipTypes.ONE_TO_ONE,
-          injectedFieldInFrom: 'other'
-        });
-        jdlObject.addEntity(userEntity);
-        jdlObject.addEntity(otherEntity);
-        jdlObject.addRelationship(relationship);
-        checker = new BusinessErrorChecker(jdlObject);
-      });
 
-      it('fails', () => {
-        expect(() => {
-          checker.checkForRelationshipErrors();
-        }).to.throw(
-          "Relationships from the User entity is not supported in the declaration between 'User' and 'Valid'."
-        );
+        it('fails', () => {
+          expect(() => {
+            checker.checkForRelationshipErrors();
+          }).to.throw(
+            "Relationships from the User entity is not supported in the declaration between 'User' and 'Valid'."
+          );
+        });
+      });
+      context('when skipUserManagement flag is set', () => {
+        before(() => {
+          const userEntity = new JDLEntity({
+            name: 'User'
+          });
+          const otherEntity = new JDLEntity({
+            name: 'Valid'
+          });
+          const relationship = new JDLRelationship({
+            from: userEntity.name,
+            to: otherEntity.name,
+            type: RelationshipTypes.ONE_TO_ONE,
+            injectedFieldInFrom: 'other'
+          });
+          jdlObject.addEntity(userEntity);
+          jdlObject.addEntity(otherEntity);
+          jdlObject.addRelationship(relationship);
+          jdlObject.addOption(
+            new JDLUnaryOption({
+              name: UnaryOptions.SKIP_USER_MANAGEMENT
+            })
+          );
+          checker = new BusinessErrorChecker(jdlObject);
+        });
+
+        it('does not fail', () => {
+          expect(() => {
+            checker.checkForRelationshipErrors();
+          }).not.to.throw();
+        });
       });
     });
     context('when the source entity is missing', () => {
@@ -560,30 +593,64 @@ describe('BusinessErrorChecker', () => {
     });
     context('when the destination entity is missing', () => {
       context('if it is the User entity', () => {
-        before(() => {
-          const sourceEntity = new JDLEntity({
-            name: 'Source'
+        context('when skipUserManagement flag is not set', () => {
+          before(() => {
+            const sourceEntity = new JDLEntity({
+              name: 'Source'
+            });
+            const otherEntity = new JDLEntity({
+              name: 'User'
+            });
+            const relationship = new JDLRelationship({
+              from: sourceEntity.name,
+              to: otherEntity.name,
+              type: RelationshipTypes.ONE_TO_ONE,
+              injectedFieldInFrom: 'other'
+            });
+            jdlObject.addEntity(sourceEntity);
+            jdlObject.addEntity(otherEntity);
+            jdlObject.addRelationship(relationship);
+            delete jdlObject.entities.User;
+            checker = new BusinessErrorChecker(jdlObject);
           });
-          const otherEntity = new JDLEntity({
-            name: 'User'
-          });
-          const relationship = new JDLRelationship({
-            from: sourceEntity.name,
-            to: otherEntity.name,
-            type: RelationshipTypes.ONE_TO_ONE,
-            injectedFieldInFrom: 'other'
-          });
-          jdlObject.addEntity(sourceEntity);
-          jdlObject.addEntity(otherEntity);
-          jdlObject.addRelationship(relationship);
-          delete jdlObject.entities.User;
-          checker = new BusinessErrorChecker(jdlObject);
-        });
 
-        it('does not fail', () => {
-          expect(() => {
-            checker.checkForRelationshipErrors();
-          }).not.to.throw();
+          it('does not fail', () => {
+            expect(() => {
+              checker.checkForRelationshipErrors();
+            }).not.to.throw();
+          });
+        });
+        context('when skipUserManagement flag is set', () => {
+          before(() => {
+            const sourceEntity = new JDLEntity({
+              name: 'Source'
+            });
+            const otherEntity = new JDLEntity({
+              name: 'User'
+            });
+            const relationship = new JDLRelationship({
+              from: sourceEntity.name,
+              to: otherEntity.name,
+              type: RelationshipTypes.ONE_TO_ONE,
+              injectedFieldInFrom: 'other'
+            });
+            jdlObject.addEntity(sourceEntity);
+            jdlObject.addEntity(otherEntity);
+            jdlObject.addRelationship(relationship);
+            jdlObject.addOption(
+              new JDLUnaryOption({
+                name: UnaryOptions.SKIP_USER_MANAGEMENT
+              })
+            );
+            delete jdlObject.entities.User;
+            checker = new BusinessErrorChecker(jdlObject);
+          });
+
+          it('fails', () => {
+            expect(() => {
+              checker.checkForRelationshipErrors();
+            }).to.throw('In the relationship between Source and User, User is not declared.');
+          });
         });
       });
       context('if it is not the User entity', () => {


### PR DESCRIPTION
If user management is skipped, the User entity can be redefined in jdl, so there's no reason to not allow relationships from it

Please make sure the below checklist is followed for Pull Requests.
  - [X] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
