### PR TITLE
Always set the otherEntityRelationshipName to the appropriate value to avoid warnings from the generator

### DIFF
--- a/lib/parser/entity_parser.js
+++ b/lib/parser/entity_parser.js
@@ -333,6 +333,9 @@ function setSourceAssociationsForClass(relatedRelationships, entityName) {
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
+      relationship.otherEntityRelationshipName = lowerFirst(
+        relatedRelationship.injectedFieldInTo || relatedRelationship.from
+      );
     } else if (relatedRelationship.type === MANY_TO_MANY) {
       splitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.otherEntityRelationshipName = lowerFirst(
@@ -341,6 +344,9 @@ function setSourceAssociationsForClass(relatedRelationships, entityName) {
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
+      relationship.otherEntityRelationshipName = lowerFirst(
+        relatedRelationship.injectedFieldInTo || relatedRelationship.from
+      );
       relationship.ownerSide = true;
     }
     entities[entityName].addRelationship(relationship);
@@ -385,15 +391,16 @@ function setDestinationAssociationsForClass(relatedRelationships, entityName) {
       relationship.otherEntityName = camelCase(relatedRelationship.from);
       relationship.relationshipType = 'one-to-many';
       otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
-      relationship.otherEntityRelationshipName = lowerFirst(otherSplitField.relationshipName);
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
     } else if (relatedRelationship.type === MANY_TO_MANY) {
       splitField = extractField(relatedRelationship.injectedFieldInTo);
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.from);
       relationship.ownerSide = false;
-      relationship.otherEntityRelationshipName = lowerFirst(
-        extractField(relatedRelationship.injectedFieldInFrom).relationshipName
-      );
+      otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
     }
     entities[entityName].addRelationship(relationship);
   });

--- a/test/spec/jdl/jdl_importer_test.js
+++ b/test/spec/jdl/jdl_importer_test.js
@@ -171,13 +171,15 @@ describe('JDLImporter', () => {
               relationshipType: 'many-to-one',
               relationshipName: 'user',
               otherEntityName: 'user',
-              otherEntityField: 'login'
+              otherEntityField: 'login',
+              otherEntityRelationshipName: 'employee'
             },
             {
               relationshipType: 'many-to-one',
               relationshipName: 'manager',
               otherEntityName: 'employee',
-              otherEntityField: 'id'
+              otherEntityField: 'id',
+              otherEntityRelationshipName: 'employee'
             },
             {
               relationshipType: 'many-to-one',
@@ -272,7 +274,7 @@ describe('JDLImporter', () => {
           relationships: [
             {
               relationshipType: 'many-to-many',
-              otherEntityRelationshipName: '',
+              otherEntityRelationshipName: 'jobHistory',
               relationshipName: 'department',
               otherEntityName: 'department',
               otherEntityField: 'id',
@@ -280,7 +282,7 @@ describe('JDLImporter', () => {
             },
             {
               relationshipType: 'many-to-many',
-              otherEntityRelationshipName: '',
+              otherEntityRelationshipName: 'jobHistory',
               relationshipName: 'department',
               otherEntityName: 'job',
               otherEntityField: 'id',
@@ -288,7 +290,7 @@ describe('JDLImporter', () => {
             },
             {
               relationshipType: 'many-to-many',
-              otherEntityRelationshipName: '',
+              otherEntityRelationshipName: 'jobHistory',
               relationshipName: 'employee',
               otherEntityName: 'employee',
               otherEntityField: 'id',

--- a/test/spec/parser/entity_parser_test.js
+++ b/test/spec/parser/entity_parser_test.js
@@ -512,7 +512,8 @@ describe('EntityParser', () => {
               relationshipName: 'bb',
               otherEntityName: 'b',
               relationshipType: 'many-to-one',
-              otherEntityField: 'id'
+              otherEntityField: 'id',
+              otherEntityRelationshipName: 'aa'
             },
             {
               relationshipName: 'bbb',


### PR DESCRIPTION
This hopefully is a fix for all other cases as well, i.e. a proper `otherEntityRelationshipName` is set either to the one provided in the jdl or automatically

Fix #299

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
