### PR TITLE
Fix regression with generation of otherEntityRelationshipName

### DIFF
--- a/lib/parser/entity_parser.js
+++ b/lib/parser/entity_parser.js
@@ -300,13 +300,13 @@ function setSourceAssociationsForClass(relatedRelationships, entityName) {
     }
     if (relatedRelationship.type === ONE_TO_ONE) {
       splitField = extractField(relatedRelationship.injectedFieldInFrom);
+      otherSplitField = extractField(relatedRelationship.injectedFieldInTo);
       relationship.relationshipName = camelCase(splitField.relationshipName) || camelCase(relatedRelationship.to);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
       relationship.ownerSide = true;
-      relationship.otherEntityRelationshipName = lowerFirst(
-        relatedRelationship.injectedFieldInTo || relatedRelationship.from
-      );
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
       if (relatedRelationship.options.has('jpaDerivedIdentifier')) {
         relationship.useJPADerivedIdentifier = true;
       }
@@ -315,7 +315,8 @@ function setSourceAssociationsForClass(relatedRelationships, entityName) {
       otherSplitField = extractField(relatedRelationship.injectedFieldInTo);
       relationship.relationshipName = camelCase(splitField.relationshipName || relatedRelationship.to);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
-      relationship.otherEntityRelationshipName = lowerFirst(otherSplitField.relationshipName);
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
       if (!relatedRelationship.injectedFieldInTo) {
         relationship.otherEntityRelationshipName = lowerFirst(relatedRelationship.from);
         otherSplitField = extractField(relatedRelationship.injectedFieldInTo);
@@ -330,23 +331,21 @@ function setSourceAssociationsForClass(relatedRelationships, entityName) {
       }
     } else if (relatedRelationship.type === MANY_TO_ONE && relatedRelationship.injectedFieldInFrom) {
       splitField = extractField(relatedRelationship.injectedFieldInFrom);
+      otherSplitField = extractField(relatedRelationship.injectedFieldInTo);
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
-      relationship.otherEntityRelationshipName = lowerFirst(
-        relatedRelationship.injectedFieldInTo || relatedRelationship.from
-      );
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
     } else if (relatedRelationship.type === MANY_TO_MANY) {
       splitField = extractField(relatedRelationship.injectedFieldInFrom);
-      relationship.otherEntityRelationshipName = lowerFirst(
-        extractField(relatedRelationship.injectedFieldInTo).relationshipName
-      );
-      relationship.relationshipName = camelCase(splitField.relationshipName);
+      otherSplitField = extractField(relatedRelationship.injectedFieldInTo);
+      relationship.relationshipName = camelCase(splitField.relationshipName || relatedRelationship.to);
       relationship.otherEntityName = camelCase(relatedRelationship.to);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
-      relationship.otherEntityRelationshipName = lowerFirst(
-        relatedRelationship.injectedFieldInTo || relatedRelationship.from
-      );
+      relationship.otherEntityRelationshipName =
+        lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
+
       relationship.ownerSide = true;
     }
     entities[entityName].addRelationship(relationship);
@@ -379,24 +378,25 @@ function setDestinationAssociationsForClass(relatedRelationships, entityName) {
       relatedRelationship.injectedFieldInTo =
         relatedRelationship.injectedFieldInTo || lowerFirst(relatedRelationship.from);
       splitField = extractField(relatedRelationship.injectedFieldInTo);
+      otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.relationshipName = camelCase(splitField.relationshipName || relatedRelationship.from);
       relationship.otherEntityName = camelCase(relatedRelationship.from);
       relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
-      otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.otherEntityRelationshipName =
         lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
     } else if (relatedRelationship.type === MANY_TO_ONE && relatedRelationship.injectedFieldInTo) {
       splitField = extractField(relatedRelationship.injectedFieldInTo);
+      otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.from);
       relationship.relationshipType = 'one-to-many';
-      otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.otherEntityRelationshipName =
         lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from);
     } else if (relatedRelationship.type === MANY_TO_MANY) {
       splitField = extractField(relatedRelationship.injectedFieldInTo);
       relationship.relationshipName = camelCase(splitField.relationshipName);
       relationship.otherEntityName = camelCase(relatedRelationship.from);
+      relationship.otherEntityField = lowerFirst(splitField.otherEntityField);
       relationship.ownerSide = false;
       otherSplitField = extractField(relatedRelationship.injectedFieldInFrom);
       relationship.otherEntityRelationshipName =

--- a/test/spec/jdl/jdl_importer_test.js
+++ b/test/spec/jdl/jdl_importer_test.js
@@ -58,7 +58,7 @@ describe('JDLImporter', () => {
             },
             {
               relationshipType: 'one-to-many',
-              relationshipName: 'region',
+              relationshipName: 'area',
               otherEntityName: 'region',
               otherEntityRelationshipName: 'country'
             }
@@ -165,7 +165,7 @@ describe('JDLImporter', () => {
               relationshipType: 'one-to-many',
               relationshipName: 'job',
               otherEntityName: 'job',
-              otherEntityRelationshipName: 'employee'
+              otherEntityRelationshipName: 'emp'
             },
             {
               relationshipType: 'many-to-one',
@@ -178,7 +178,7 @@ describe('JDLImporter', () => {
               relationshipType: 'many-to-one',
               relationshipName: 'manager',
               otherEntityName: 'employee',
-              otherEntityField: 'id',
+              otherEntityField: 'director',
               otherEntityRelationshipName: 'employee'
             },
             {
@@ -229,7 +229,7 @@ describe('JDLImporter', () => {
           relationships: [
             {
               relationshipType: 'many-to-many',
-              otherEntityRelationshipName: 'job',
+              otherEntityRelationshipName: 'linkedJob',
               relationshipName: 'chore',
               otherEntityName: 'task',
               otherEntityField: 'title',
@@ -237,10 +237,18 @@ describe('JDLImporter', () => {
             },
             {
               relationshipType: 'many-to-one',
-              relationshipName: 'employee',
+              relationshipName: 'emp',
               otherEntityName: 'employee',
               otherEntityRelationshipName: 'job',
-              otherEntityField: 'id'
+              otherEntityField: 'employee'
+            },
+            {
+              relationshipType: 'many-to-many',
+              relationshipName: 'history',
+              otherEntityName: 'jobHistory',
+              otherEntityRelationshipName: 'jobHistory',
+              otherEntityField: 'id',
+              ownerSide: false
             }
           ],
           name: 'Job',
@@ -282,8 +290,8 @@ describe('JDLImporter', () => {
             },
             {
               relationshipType: 'many-to-many',
-              otherEntityRelationshipName: 'jobHistory',
-              relationshipName: 'department',
+              otherEntityRelationshipName: 'history',
+              relationshipName: 'job',
               otherEntityName: 'job',
               otherEntityField: 'id',
               ownerSide: true
@@ -291,9 +299,9 @@ describe('JDLImporter', () => {
             {
               relationshipType: 'many-to-many',
               otherEntityRelationshipName: 'jobHistory',
-              relationshipName: 'employee',
+              relationshipName: 'emp',
               otherEntityName: 'employee',
-              otherEntityField: 'id',
+              otherEntityField: 'employee',
               ownerSide: true
             }
           ],
@@ -389,9 +397,10 @@ describe('JDLImporter', () => {
           relationships: [
             {
               relationshipType: 'many-to-many',
-              relationshipName: 'job',
+              relationshipName: 'linkedJob',
               otherEntityName: 'job',
               ownerSide: false,
+              otherEntityField: 'jobTitle',
               otherEntityRelationshipName: 'chore'
             }
           ],

--- a/test/spec/parser/entity_parser_test.js
+++ b/test/spec/parser/entity_parser_test.js
@@ -550,6 +550,7 @@ describe('EntityParser', () => {
               otherEntityName: 'a',
               relationshipType: 'many-to-many',
               ownerSide: false,
+              otherEntityField: 'id',
               otherEntityRelationshipName: 'bbb'
             }
           ]);

--- a/test/test_files/big_sample.jdl
+++ b/test/test_files/big_sample.jdl
@@ -79,21 +79,21 @@ relationship OneToMany {
    * Another side of the same relationship,
    */
   Employee{department},
-  Employee{job} to Job{employee},
+  Employee{job} to Job{emp(employee)},
   Location{country} to Country,
-  Country{region} to Region
+  Country{area(region)} to Region
 }
 
 relationship ManyToOne {
   Employee{user(login)} to User{employee},
-  Employee{manager} to Employee
+  Employee{manager(director)} to Employee
 }
 
 relationship ManyToMany {
   JobHistory{department} to Department,
-  JobHistory{department} to Job,
-  JobHistory{employee} to Employee,
-  Job{chore(title)} to Task{job}
+  JobHistory to Job{history},
+  JobHistory{emp(employee)} to Employee,
+  Job{chore(title)} to Task{linkedJob(JobTitle)}
 }
 
 paginate JobHistory, Employee with infinite-scroll


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/9202

Fix regression with generation of `otherEntityRelationshipName` 
generated for owning `ManyToMany` field that also has display field defined

- Similar issue fixed for source `OneToOne`, `OneToMany` and `ManyToOne`
  relationships
- Added missing `otherEntityField` for dest `ManyToMany` relationship
- Modified uni tests accordingly to account for more use cases

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
