### PR TITLE
Fix invalid otherEntityRelationshipName generated for the destination association

### DIFF
--- a/lib/parser/entity_parser.js
+++ b/lib/parser/entity_parser.js
@@ -340,7 +340,7 @@ function setDestinationAssociationsForClass(relatedRelationships, entityName) {
     const relationship = {
       relationshipType: _.kebabCase(relationshipType),
       otherEntityName: camelCase(relatedRelationship.from),
-      otherEntityRelationshipName: lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.from)
+      otherEntityRelationshipName: lowerFirst(otherSplitField.relationshipName) || camelCase(relatedRelationship.to)
     };
     if (relatedRelationship.isInjectedFieldInToRequired) {
       relationship.relationshipValidateRules = REQUIRED;

--- a/test/spec/jdl/jdl_importer_test.js
+++ b/test/spec/jdl/jdl_importer_test.js
@@ -178,7 +178,7 @@ describe('JDLImporter', () => {
               relationshipType: 'many-to-one',
               relationshipName: 'manager',
               otherEntityName: 'employee',
-              otherEntityField: 'director',
+              otherEntityField: 'lastName',
               otherEntityRelationshipName: 'employee'
             },
             {
@@ -246,7 +246,7 @@ describe('JDLImporter', () => {
               relationshipType: 'many-to-many',
               relationshipName: 'history',
               otherEntityName: 'jobHistory',
-              otherEntityRelationshipName: 'jobHistory',
+              otherEntityRelationshipName: 'job',
               otherEntityField: 'id',
               ownerSide: false
             }

--- a/test/spec/parser/entity_parser_test.js
+++ b/test/spec/parser/entity_parser_test.js
@@ -753,7 +753,7 @@ describe('EntityParser', () => {
 
         it('sets one by default', () => {
           expect(content.A.relationships[0].relationshipName).to.equal('b');
-          expect(content.B.relationships[0].otherEntityRelationshipName).to.equal('a');
+          expect(content.B.relationships[0].otherEntityRelationshipName).to.equal('b');
         });
       });
       context('when parsing a relationship with a useJPADerivedIdentifier flag', () => {

--- a/test/test_files/big_sample.jdl
+++ b/test/test_files/big_sample.jdl
@@ -86,7 +86,7 @@ relationship OneToMany {
 
 relationship ManyToOne {
   Employee{user(login)} to User{employee},
-  Employee{manager(director)} to Employee
+  Employee{manager(lastName)} to Employee
 }
 
 relationship ManyToMany {


### PR DESCRIPTION
Hello @MathieuAA. First off thanks for cleaning up `entity_parser.js`.

I have submitted a PR in generator-jhipster to improve the JDL import CI test.: https://github.com/jhipster/generator-jhipster/pull/9217. What I have basically done is merge the previous `app.jdl` with the `big_sample.jdl` used in the core in order to have more test cases at the generator as well.

While testing this today I found that the otherEntityRelationshipName generated for the destination association is invalid hence this PR.

More specifically the following 
```
relationship ManyToMany {
  JobHistory to Job{history},
}
```
generates `otherEntityRelationshipName=jobHistory` for `Job` while it should have been '`otherEntityRelationshipName=job`'

I also changed 
```
relationship ManyToOne {
  Employee{manager(director)} to Employee
}
```
to
```
relationship ManyToOne {
  Employee{manager(lastName)} to Employee
}
``` 
in order to refer to an actual field of the `Employee` entity.

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
