### PR TITLE
[WIP] Enabling specification of cacheProvider when generating application through import-jdl

### DIFF
--- a/lib/core/jhipster/application_options.js
+++ b/lib/core/jhipster/application_options.js
@@ -43,6 +43,7 @@ const Options = {
     ehcache: 'ehcache',
     hazelcast: 'hazelcast',
     infinispan: 'infinispan',
+    memcached: 'memcached',
     no: 'no'
   },
   clientFramework: {


### PR DESCRIPTION
Currently, the import-jdl feature cannot parse the line
`cacheProvider memcached`
to generate an application. I've added the memcached option to the applications_configs.js

It doesn't generate the application with the cacheProvider option provided to the .jdl file but with hazelcast everytime.

This PR is a fix attempt to [issue#317](https://github.com/jhipster/jhipster-core/issues/317)

Please make sure the below checklist is followed for Pull Requests.
  - [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-umk/pull_requests) are green
  - [x] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Added memcached option to the parser
  - [ ] Generate applications that does not have hazelcast as cache provider
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
