### PR TITLE
Add vuejs client framework to application options

### DIFF
--- a/lib/core/jhipster/application_options.js
+++ b/lib/core/jhipster/application_options.js
@@ -48,7 +48,8 @@ const Options = {
   clientFramework: {
     angularX: 'angularX',
     angular: 'angular',
-    react: 'react'
+    react: 'react',
+    vuejs: 'vuejs'
   },
   clientPackageManager: {
     yarn: 'yarn',


### PR DESCRIPTION
This is a workaround to let users generate apps with the JDL for the vuejs blueprint. 

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-core/pull_requests) are green
  - [ ] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
