### PR TITLE
preserve original entity changelogDate

### DIFF
--- a/lib/export/jhipster_entity_exporter.js
+++ b/lib/export/jhipster_entity_exporter.js
@@ -127,6 +127,7 @@ function updateEntityToGenerateWithExistingOne(filePath, entity) {
   if (FileUtils.doesFileExist(filePath)) {
     const fileOnDisk = readEntityJSON(filePath);
     if (fileOnDisk && fileOnDisk.changelogDate) {
+      entity.changelogDate = fileOnDisk.changelogDate;
       return { ...fileOnDisk, ...entity };
     }
   }

--- a/test/spec/export/jhipster_entity_exporter_test.js
+++ b/test/spec/export/jhipster_entity_exporter_test.js
@@ -653,8 +653,10 @@ describe('JHipsterEntityExporter', () => {
             path.join('.jhipster', 'A.json'),
             JSON.stringify({ ...originalContent, customAttribute: '42' })
           );
+          const changedContent = JSON.parse(JSON.stringify(originalContent));
+          changedContent.changelogDate = '43';
           const entities = {
-            A: originalContent
+            A: changedContent
           };
           JHipsterEntityExporter.exportEntities({
             entities,
@@ -671,7 +673,7 @@ describe('JHipsterEntityExporter', () => {
           fs.rmdirSync('.jhipster');
         });
 
-        it('merges the existing content with the new one', () => {
+        it('merges the existing content with the new one and preserves changelogDate original value', () => {
           expect(newContent).to.deep.equal({
             ...originalContent,
             customAttribute: '42'


### PR DESCRIPTION
fixes regression caused by this line removal: https://github.com/jhipster/jhipster-core/commit/d39e15f0e584318c20e70caffe1ce57769ab5f1c#diff-f6c0500618fe74400adc08cfc6620eaaL131
fix jhipster/generator-jhipster#9996

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-core/pull_requests) are green
  - [x] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
