### PR TITLE
fix areEntitiesEqual for entities from JDL without javadoc

### DIFF
--- a/lib/utils/object_utils.js
+++ b/lib/utils/object_utils.js
@@ -44,9 +44,17 @@ function merge(object1, object2) {
   };
 }
 
+function removeEntriesWithUndefinedValue(entity) {
+  Object.keys(entity).forEach(key => {
+    if (entity[key] === undefined) {
+      delete entity[key];
+    }
+  });
+}
+
 function areEntitiesEqual(firstEntity, secondEntity) {
-  Object.keys(firstEntity).forEach(key => firstEntity[key] === undefined && delete firstEntity[key]);
-  Object.keys(secondEntity).forEach(key => secondEntity[key] === undefined && delete secondEntity[key]);
+  removeEntriesWithUndefinedValue(firstEntity);
+  removeEntriesWithUndefinedValue(secondEntity);
   if (
     firstEntity.fields.length !== secondEntity.fields.length ||
     firstEntity.relationships.length !== secondEntity.relationships.length ||

--- a/lib/utils/object_utils.js
+++ b/lib/utils/object_utils.js
@@ -45,6 +45,8 @@ function merge(object1, object2) {
 }
 
 function areEntitiesEqual(firstEntity, secondEntity) {
+  Object.keys(firstEntity).forEach(key => firstEntity[key] === undefined && delete firstEntity[key]);
+  Object.keys(secondEntity).forEach(key => secondEntity[key] === undefined && delete secondEntity[key]);
   if (
     firstEntity.fields.length !== secondEntity.fields.length ||
     firstEntity.relationships.length !== secondEntity.relationships.length ||

--- a/test/spec/utils/object_utils_test.js
+++ b/test/spec/utils/object_utils_test.js
@@ -191,6 +191,22 @@ describe('ObjectUtils', () => {
           expect(ObjectUtils.areEntitiesEqual(firstObject, secondObject)).to.be.true;
         });
       });
+      context('one object has key with undefined value, second object does not have this key', () => {
+        it('returns true', () => {
+          const firstObject = {
+            name: 'MyEntity',
+            fields: [],
+            relationships: [],
+            javadoc: undefined
+          };
+          const secondObject = {
+            name: 'MyEntity',
+            fields: [],
+            relationships: []
+          };
+          expect(ObjectUtils.areEntitiesEqual(firstObject, secondObject)).to.be.true;
+        });
+      });
     });
     context('when comparing two unequal objects', () => {
       context('as one of them is not empty, the other is', () => {


### PR DESCRIPTION
fix #341

Feel free to close this PR if there is better fix for #341

Please make sure the below checklist is followed for Pull Requests.
  - [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-core/pull_requests) are green
  - [x] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
