### PR TITLE
Added more cases to the relationship validator

### DIFF
--- a/lib/exceptions/business_error_checker.js
+++ b/lib/exceptions/business_error_checker.js
@@ -148,17 +148,14 @@ class BusinessErrorChecker {
   }
 
   checkForRelationshipErrors() {
-    const validator = new RelationshipValidator();
+    const skippedUserManagement = this.jdlObject.getOptionsForName(SKIP_USER_MANAGEMENT)[0];
+    const validator = new RelationshipValidator(skippedUserManagement);
     this.jdlObject.forEachRelationship(jdlRelationship => {
       validator.validate(jdlRelationship);
       checkForAbsentEntities({
         jdlRelationship,
         doesEntityExist: entityName => !!this.jdlObject.getEntity(entityName),
-        skippedUserManagementOption: this.jdlObject.getOptionsForName(SKIP_USER_MANAGEMENT)[0]
-      });
-      checkForForbiddenUseOfUserAsSource({
-        jdlRelationship,
-        skippedUserManagementOption: this.jdlObject.getOptionsForName(SKIP_USER_MANAGEMENT)[0]
+        skippedUserManagementOption: skippedUserManagement
       });
       checkForRelationshipsBetweenApplications({
         jdlRelationship,
@@ -271,15 +268,6 @@ function checkForAbsentEntities({ jdlRelationship, doesEntityExist, skippedUserM
     throw new Error(
       `In the relationship between ${jdlRelationship.from} and ${jdlRelationship.to}, ` +
         `${absentEntities.join(' and ')} ${absentEntities.length === 1 ? 'is' : 'are'} not declared.`
-    );
-  }
-}
-
-function checkForForbiddenUseOfUserAsSource({ jdlRelationship, skippedUserManagementOption }) {
-  if (jdlRelationship.from.toLowerCase() === 'user' && !skippedUserManagementOption) {
-    throw new Error(
-      `Relationships from the User entity is not supported in the declaration between '${jdlRelationship.from}' and ` +
-        `'${jdlRelationship.to}'. You can have this by using the '${SKIP_USER_MANAGEMENT}' option.`
     );
   }
 }

--- a/lib/exceptions/relationship_validator.js
+++ b/lib/exceptions/relationship_validator.js
@@ -28,13 +28,14 @@ class RelationshipValidator extends Validator {
     super('relationship', ['from', 'to', 'type']);
   }
 
-  validate(jdlRelationship) {
+  validate(jdlRelationship, skippedUserManagementOption) {
     super.validate(jdlRelationship);
     checkType(jdlRelationship);
     checkInjectedFields(jdlRelationship);
     checkForValidUseOfJPaDerivedIdentifier(jdlRelationship);
     checkForRequiredReflexiveRelationship(jdlRelationship);
-    checkRelationshipType(jdlRelationship);
+    checkForInvalidUseOfTheUserEntity(jdlRelationship, skippedUserManagementOption);
+    checkRelationshipType(jdlRelationship, skippedUserManagementOption);
   }
 }
 
@@ -70,41 +71,37 @@ function checkForRequiredReflexiveRelationship(jdlRelationship) {
   }
 }
 
-function checkRelationshipType(jdlRelationship) {
+function checkForInvalidUseOfTheUserEntity(jdlRelationship, skippedUserManagementOption) {
+  const userIsTheSourceAndTheDestination = isEntityTheUser(jdlRelationship.from) && isEntityTheUser(jdlRelationship.to);
+  if (userIsTheSourceAndTheDestination && !skippedUserManagementOption) {
+    throw new Error(
+      'Having the source and the destination entities being the User is forbidden unless the User ' +
+        "entity is not managed by JHipster (use the 'skipUserManagement' option)."
+    );
+  }
+  checkForForbiddenUseOfUserAsSource(jdlRelationship, skippedUserManagementOption);
+}
+
+function checkForForbiddenUseOfUserAsSource(jdlRelationship, skippedUserManagementOption) {
+  const userIsTheSource = isEntityTheUser(jdlRelationship.from);
+  if (userIsTheSource && !skippedUserManagementOption) {
+    throw new Error(
+      `Relationships from the User entity is not supported in the declaration between '${jdlRelationship.from}' and ` +
+        `'${jdlRelationship.to}'. You can have this by using the 'skipUserManagement' option.`
+    );
+  }
+}
+
+function checkRelationshipType(jdlRelationship, skippedUserManagementOption) {
   switch (jdlRelationship.type) {
     case ONE_TO_ONE:
-      if (!jdlRelationship.injectedFieldInFrom) {
-        throw new Error(
-          `In the One-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
-            'the source entity must possess the source, ' +
-            'or you must invert the direction of the relationship.'
-        );
-      }
+      checkOneToOneRelationship(jdlRelationship, skippedUserManagementOption);
       break;
     case MANY_TO_ONE:
-      if (jdlRelationship.injectedFieldInFrom && jdlRelationship.injectedFieldInTo) {
-        throw new Error(
-          `In the Many-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
-            'only unidirectionality is supported, ' +
-            'you should either create a bidirectional One-to-Many relationship or ' +
-            'remove the injected field in the destination entity instead.'
-        );
-      }
+      checkManyToOneRelationship(jdlRelationship, skippedUserManagementOption);
       break;
     case MANY_TO_MANY:
-      if (!jdlRelationship.injectedFieldInFrom || !jdlRelationship.injectedFieldInTo) {
-        const injectedFieldInSourceEntity = !jdlRelationship.injectedFieldInFrom
-          ? 'not set'
-          : `'${jdlRelationship.injectedFieldInFrom}'`;
-        const injectedFieldInDestinationEntity = !jdlRelationship.injectedFieldInTo
-          ? 'not set'
-          : `'${jdlRelationship.injectedFieldInTo}'`;
-        throw new Error(
-          `In the Many-to-Many relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, only ` +
-            `bidirectionality is supported. The injected field in the source entity is ${injectedFieldInSourceEntity} ` +
-            `and the injected field in the destination entity is ${injectedFieldInDestinationEntity}.`
-        );
-      }
+      checkManyToManyRelationship(jdlRelationship);
       break;
     case ONE_TO_MANY:
       return;
@@ -112,4 +109,64 @@ function checkRelationshipType(jdlRelationship) {
       // never happens, ever.
       throw new Error(`This case shouldn't have happened with type ${jdlRelationship.type}.`);
   }
+}
+
+function checkOneToOneRelationship(jdlRelationship) {
+  if (!jdlRelationship.injectedFieldInFrom) {
+    throw new Error(
+      `In the One-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
+        'the source entity must possess the destination, or you must invert the direction of the relationship.'
+    );
+  }
+}
+
+function checkManyToOneRelationship(jdlRelationship, skippedUserManagementOption) {
+  const bidirectionalRelationship = jdlRelationship.injectedFieldInFrom && jdlRelationship.injectedFieldInTo;
+  if (bidirectionalRelationship) {
+    throw new Error(
+      `In the Many-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
+        'only unidirectionality is supported, you should either create a bidirectional One-to-Many relationship or ' +
+        'remove the injected field in the destination entity instead.'
+    );
+  }
+  const unidirectionalRelationship = !jdlRelationship.injectedFieldInFrom || !jdlRelationship.injectedFieldInTo;
+  const userIsTheSourceEntity = isEntityTheUser(jdlRelationship.from);
+  const userIsTheDestinationEntity = isEntityTheUser(jdlRelationship.to);
+  const userHasTheInjectedField =
+    (userIsTheSourceEntity && jdlRelationship.injectedFieldInFrom) ||
+    (userIsTheDestinationEntity && jdlRelationship.injectedFieldInTo);
+  if (unidirectionalRelationship && userHasTheInjectedField && !skippedUserManagementOption) {
+    throw new Error(
+      `In the Many-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
+        'the User entity has the injected field without its management being skipped. ' +
+        "To have such a relation, you should use the 'skipUserManagement' option."
+    );
+  }
+}
+
+function checkManyToManyRelationship(jdlRelationship) {
+  const destinationEntityIsTheUser = isEntityTheUser(jdlRelationship.to);
+  if (jdlRelationship.injectedFieldInFrom && !jdlRelationship.injectedFieldInTo && destinationEntityIsTheUser) {
+    // This is a valid case: even though bidirectionality is required for MtM relationships, having the destination
+    // entity being the User is possible.
+    return;
+  }
+  const unidirectionalRelationship = !jdlRelationship.injectedFieldInFrom || !jdlRelationship.injectedFieldInTo;
+  if (unidirectionalRelationship) {
+    const injectedFieldInSourceEntity = !jdlRelationship.injectedFieldInFrom
+      ? 'not set'
+      : `'${jdlRelationship.injectedFieldInFrom}'`;
+    const injectedFieldInDestinationEntity = !jdlRelationship.injectedFieldInTo
+      ? 'not set'
+      : `'${jdlRelationship.injectedFieldInTo}'`;
+    throw new Error(
+      `In the Many-to-Many relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, only ` +
+        `bidirectionality is supported. The injected field in the source entity is ${injectedFieldInSourceEntity} ` +
+        `and the injected field in the destination entity is ${injectedFieldInDestinationEntity}.`
+    );
+  }
+}
+
+function isEntityTheUser(entityName) {
+  return entityName.toLowerCase() === 'user';
 }

--- a/test/spec/converters/json_to_jdl_entity_converter.spec.js
+++ b/test/spec/converters/json_to_jdl_entity_converter.spec.js
@@ -305,6 +305,26 @@ describe('JSONToJDLEntityConverter', () => {
         });
       });
     });
+    context('when parsing relationships including the User entity', () => {
+      let entity;
+
+      before(() => {
+        entity = {
+          TestEntity: JSON.parse(
+            fs
+              .readFileSync(
+                path.join('test', 'test_files', 'json_to_jdl_converter', 'with_user', '.jhipster', 'TestEntity.json'),
+                'utf-8'
+              )
+              .toString()
+          )
+        };
+      });
+
+      it('should not fail', () => {
+        expect(() => convertEntitiesToJDL(entity)).not.to.throw();
+      });
+    });
   });
 });
 

--- a/test/spec/exceptions/business_error_checker.spec.js
+++ b/test/spec/exceptions/business_error_checker.spec.js
@@ -421,59 +421,6 @@ describe('BusinessErrorChecker', () => {
     });
   });
   describe('#checkForRelationshipErrors', () => {
-    context('when having User as source entity', () => {
-      let checker;
-      let jdlObject;
-
-      before(() => {
-        jdlObject = new ValidatedJDLObject();
-        const userEntity = new JDLEntity({
-          name: 'User'
-        });
-        const otherEntity = new JDLEntity({
-          name: 'Valid'
-        });
-        const relationship = new JDLRelationship({
-          from: userEntity.name,
-          to: otherEntity.name,
-          type: RelationshipTypes.ONE_TO_ONE,
-          injectedFieldInFrom: 'other'
-        });
-        jdlObject.addEntity(userEntity);
-        jdlObject.addEntity(otherEntity);
-        jdlObject.addRelationship(relationship);
-        checker = new BusinessErrorChecker(jdlObject);
-      });
-
-      context('when skipUserManagement flag is not set', () => {
-        it('fails', () => {
-          expect(() => {
-            checker.checkForRelationshipErrors();
-          }).to.throw(
-            new RegExp(
-              "Relationships from the User entity is not supported in the declaration between 'User' and " +
-                "'Valid'. You can have this by using the 'skipUserManagement' option."
-            )
-          );
-        });
-      });
-      context('when skipUserManagement flag is set', () => {
-        before(() => {
-          jdlObject.addOption(
-            new JDLUnaryOption({
-              name: UnaryOptions.SKIP_USER_MANAGEMENT
-            })
-          );
-          checker = new BusinessErrorChecker(jdlObject);
-        });
-
-        it('does not fail', () => {
-          expect(() => {
-            checker.checkForRelationshipErrors();
-          }).not.to.throw();
-        });
-      });
-    });
     context('when the source entity is missing', () => {
       let checker;
 

--- a/test/spec/exceptions/relationship_validator.spec.js
+++ b/test/spec/exceptions/relationship_validator.spec.js
@@ -163,7 +163,7 @@ describe('RelationshipValidator', () => {
 
           it('should fail', () => {
             expect(() => validator.validate(relationship)).to.throw(
-              /^In the One-to-One relationship from A to B, the source entity must possess the source, or you must invert the direction of the relationship\.$/
+              /^In the One-to-One relationship from A to B, the source entity must possess the destination, or you must invert the direction of the relationship\.$/
             );
           });
         });
@@ -220,6 +220,152 @@ describe('RelationshipValidator', () => {
             it('should fail', () => {
               expect(() => validator.validate(relationship2)).to.throw(
                 /^In the Many-to-Many relationship from A to B, only bidirectionality is supported\. The injected field in the source entity is 'b' and the injected field in the destination entity is not set\.$/
+              );
+            });
+          });
+        });
+      });
+      context('with the user entity', () => {
+        context(`when having a ${ONE_TO_ONE} relationship`, () => {
+          context('having an injected field in the source entity', () => {
+            let relationship;
+
+            before(() => {
+              relationship = {
+                from: 'A',
+                to: 'User',
+                type: ONE_TO_ONE,
+                injectedFieldInFrom: 'user'
+              };
+            });
+
+            it('should not fail', () => {
+              expect(() => validator.validate(relationship)).not.to.throw();
+            });
+          });
+          context('having the source entity as user', () => {
+            let relationship;
+
+            before(() => {
+              relationship = {
+                from: 'User',
+                to: 'A',
+                type: ONE_TO_ONE,
+                injectedFieldInFrom: 'a'
+              };
+            });
+
+            it('should fail', () => {
+              expect(() => validator.validate(relationship)).to.throw(
+                /^Relationships from the User entity is not supported in the declaration between 'User' and 'A'\. You can have this by using the 'skipUserManagement' option\.$/
+              );
+            });
+          });
+        });
+        context(`when having a ${MANY_TO_ONE} relationship`, () => {
+          context('without the User having the injected field', () => {
+            let relationship;
+
+            before(() => {
+              relationship = new JDLRelationship({
+                from: 'A',
+                to: 'User',
+                type: MANY_TO_ONE,
+                injectedFieldInFrom: 'user'
+              });
+            });
+
+            it('should not fail', () => {
+              expect(() => validator.validate(relationship)).not.to.throw();
+            });
+          });
+          context('with the User having the injected field', () => {
+            context('with the skipUserManagement option', () => {
+              let relationship;
+
+              before(() => {
+                relationship = new JDLRelationship({
+                  from: 'User',
+                  to: 'A',
+                  type: MANY_TO_ONE,
+                  injectedFieldInFrom: 'a'
+                });
+              });
+
+              it('should not fail', () => {
+                expect(() => validator.validate(relationship, true)).not.to.throw();
+              });
+            });
+            context('as the source', () => {
+              let relationship;
+
+              before(() => {
+                relationship = new JDLRelationship({
+                  from: 'User',
+                  to: 'A',
+                  type: MANY_TO_ONE,
+                  injectedFieldInFrom: 'a'
+                });
+              });
+
+              it('should fail', () => {
+                expect(() => validator.validate(relationship)).to.throw(
+                  /^Relationships from the User entity is not supported in the declaration between 'User' and 'A'\. You can have this by using the 'skipUserManagement' option\.$/
+                );
+              });
+            });
+            context('as the destination', () => {
+              let relationship;
+
+              before(() => {
+                relationship = new JDLRelationship({
+                  from: 'A',
+                  to: 'User',
+                  type: MANY_TO_ONE,
+                  injectedFieldInTo: 'a'
+                });
+              });
+
+              it('should fail', () => {
+                expect(() => validator.validate(relationship)).to.throw(
+                  /^In the Many-to-One relationship from A to User, the User entity has the injected field without its management being skipped\. To have such a relation, you should use the 'skipUserManagement' option\.$/
+                );
+              });
+            });
+          });
+        });
+        context(`when having a ${MANY_TO_MANY} relationship`, () => {
+          context('with the user being the destination', () => {
+            let relationship;
+
+            before(() => {
+              relationship = new JDLRelationship({
+                from: 'A',
+                to: 'User',
+                type: MANY_TO_MANY,
+                injectedFieldInFrom: 'user'
+              });
+            });
+
+            it('should not fail', () => {
+              expect(() => validator.validate(relationship)).not.to.throw();
+            });
+          });
+          context('with the user being the source', () => {
+            let relationship;
+
+            before(() => {
+              relationship = new JDLRelationship({
+                from: 'User',
+                to: 'A',
+                type: MANY_TO_MANY,
+                injectedFieldInTo: 'a'
+              });
+            });
+
+            it('should fail', () => {
+              expect(() => validator.validate(relationship)).to.throw(
+                /^Relationships from the User entity is not supported in the declaration between 'User' and 'A'. You can have this by using the 'skipUserManagement' option\.$/
               );
             });
           });

--- a/test/test_files/json_to_jdl_converter/with_user/.jhipster/TestEntity.json
+++ b/test/test_files/json_to_jdl_converter/with_user/.jhipster/TestEntity.json
@@ -1,0 +1,34 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipName": "userOneToMany",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-one",
+            "relationshipValidateRules": "required",
+            "otherEntityField": "login"
+        },
+        {
+            "relationshipName": "userManyToMany",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "login",
+            "ownerSide": true
+        },
+        {
+            "relationshipName": "userOneToOne",
+            "otherEntityName": "user",
+            "relationshipType": "one-to-one",
+            "otherEntityField": "login",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "parent"
+        }
+    ],
+    "fields": [],
+    "changelogDate": "20160208210109",
+    "dto": "no",
+    "service": "no",
+    "jpaMetamodelFiltering": true,
+    "angularJSSuffix": "mySuffixAlt",
+    "pagination": "no"
+}

--- a/test/test_files/json_to_jdl_converter/with_user/.yo-rc.json
+++ b/test/test_files/json_to_jdl_converter/with_user/.yo-rc.json
@@ -1,0 +1,35 @@
+{
+  "generator-jhipster": {
+    "promptValues": {
+      "packageName": "com.mycompany.myapp"
+    },
+    "jhipsterVersion": "6.0.1",
+    "applicationType": "microservice",
+    "baseName": "truc",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "serverPort": "8081",
+    "authenticationType": "jwt",
+    "cacheProvider": "hazelcast",
+    "enableHibernateCache": true,
+    "websocket": false,
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": false,
+    "messageBroker": false,
+    "serviceDiscoveryType": "eureka",
+    "buildTool": "maven",
+    "enableSwaggerCodegen": false,
+    "jwtSecretKey": "HIDDEN",
+    "testFrameworks": [],
+    "jhiPrefix": "jhi",
+    "entitySuffix": "",
+    "dtoSuffix": "DTO",
+    "otherModules": [],
+    "enableTranslation": false,
+    "clientPackageManager": "npm",
+    "skipClient": true,
+    "skipUserManagement": true
+  }
+}


### PR DESCRIPTION
Cases:
  - MtO:
    - if the User entity has the injected field without the skipUserMgt option set, it should fail
  - MtM:
    - if there is an unidirectional relationship to the User, it should not fail as this is a valid case

@pascalgrimaud I've shamelessly taken the sample from the generator for my tests, ideally this project should have been included in the generator and this mess could have been avoided... :(
