### PR TITLE
add script to generate a diagram of JDL grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log
 jhipster-core.iml
 .project
 .vscode/*
+diagrams.html

--- a/scripts/gen-diagrams.js
+++ b/scripts/gen-diagrams.js
@@ -1,0 +1,21 @@
+/**
+ * A template for generating syntax diagrams html file.
+ * See: https://github.com/SAP/chevrotain/tree/master/diagrams for more details
+ */
+const path = require('path');
+const fs = require('fs');
+const chevrotain = require('chevrotain');
+
+const JDLParser = require('../lib/dsl/jdl_parser');
+
+// extract the serialized grammar.
+const parserInstance = JDLParser.getParser();
+parserInstance.parse();
+const serializedGrammar = parserInstance.getSerializedGastProductions();
+
+// create the HTML Text
+const htmlText = chevrotain.createSyntaxDiagramsCode(serializedGrammar);
+
+// Write the HTML file to disk
+const outPath = path.resolve(__dirname, './');
+fs.writeFileSync(`${outPath}/../diagrams.html`, htmlText);


### PR DESCRIPTION
Hi @MathieuAA!

I just created this PR to show you a chevrotain tool that I found really useful in the Java parser we developed: it generates an HTML diagram of the JDL grammar. I think it could be useful when debugging some tricky bugs

Please make sure the below checklist is followed for Pull Requests.
  - [ ] Checks are green
  - [ ] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed