### PR TITLE
Do not allow underscore in baseName to prevent invalid hostnames

### DIFF
--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -59,7 +59,7 @@ const configPropsValidations = {
   },
   BASE_NAME: {
     type: 'NAME',
-    pattern: ALPHANUMERIC_UNDERSCORE,
+    pattern: ALPHANUMERIC,
     msg: 'baseName property'
   },
   BLUEPRINT: {

--- a/test/spec/jdl/jdl_importer.spec.js
+++ b/test/spec/jdl/jdl_importer.spec.js
@@ -1119,24 +1119,17 @@ describe('JDLImporter', () => {
       });
     });
     context('when parsing a JDL with underscores contained in the application name', () => {
-      let returned;
-
-      before(() => {
-        const importer = createImporterFromFiles([path.join('test', 'test_files', 'underscore_application_name.jdl')]);
-        returned = importer.import();
-      });
-
       after(() => {
         fse.removeSync('.jhipster');
         fse.removeSync('.yo-rc.json');
       });
 
-      it('accept underscore application name', () => {
-        expect(returned.exportedApplications[0]['generator-jhipster'].baseName.includes('_')).to.be.true;
-      });
-
-      it('accept underscore appsFolders name', () => {
-        expect(returned.exportedDeployments[0]['generator-jhipster'].appsFolders[0].includes('_')).to.be.true;
+      it('fails to create application with underscores in base name', () => {
+        expect(() =>
+          createImporterFromFiles([path.join('test', 'test_files', 'underscore_application_name.jdl')])
+        ).to.throw(
+          'Error: The baseName property name must match: /^[A-Za-z][A-Za-z0-9]*$/, got my_underscore_app.\n\tat line: 5, column: 14'
+        );
       });
     });
     context('when parsing JDL applications and deployment config', () => {


### PR DESCRIPTION
Please make sure the below checklist is followed for Pull Requests.
  - [x] Checks are green
  - [x] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed

Fixes #417 with the suggested fix "Add error message when user tries to generate microservice with an underscore or illegal character according to URI spec in the service name."

However, i would like to use dashes. May I make another PR or is there a good reason against dashes in baseName?