### PR TITLE
Skip Hard Stop Error Message When OptionType Does Not Exist

### DIFF
--- a/lib/core/jdl_application_configuration_factory.js
+++ b/lib/core/jdl_application_configuration_factory.js
@@ -22,7 +22,14 @@ const StringJDLApplicationConfigurationOption = require('./string_jdl_applicatio
 const IntegerJDLApplicationConfigurationOption = require('./integer_jdl_application_configuration_option');
 const BooleanJDLApplicationConfigurationOption = require('./boolean_jdl_application_configuration_option');
 const ListJDLApplicationConfigurationOption = require('./list_jdl_application_configuration_option');
-const { getTypeForOption, OptionTypes, shouldTheValueBeQuoted } = require('./jhipster/application_options');
+const {
+  getTypeForOption,
+  doesOptionExist,
+  OptionTypes,
+  shouldTheValueBeQuoted
+} = require('./jhipster/application_options');
+
+const logger = require('../utils/objects/logger');
 
 module.exports = { createApplicationConfigurationFromObject };
 
@@ -30,6 +37,10 @@ function createApplicationConfigurationFromObject(configurationObject = {}) {
   const configuration = new JDLApplicationConfiguration();
   Object.keys(configurationObject).forEach(optionName => {
     const optionValue = configurationObject[optionName];
+    if (!doesOptionExist(optionName, optionValue)) {
+      logger.debug(`Unrecognized application option name and value: ${optionName} and ${optionValue}`);
+      return;
+    }
     configuration.setOption(createJDLConfigurationOption(optionName, optionValue));
   });
   return configuration;

--- a/test/spec/exceptions/application_validator.spec.js
+++ b/test/spec/exceptions/application_validator.spec.js
@@ -18,7 +18,12 @@
  */
 
 /* eslint-disable no-new, no-unused-expressions */
-const { expect } = require('chai');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 const ApplicationValidator = require('../../../lib/validators/application_validator');
 
@@ -34,6 +39,7 @@ const {
   NEO4J
 } = require('../../../lib/core/jhipster/database_types');
 const JDLApplication = require('../../../lib/core/jdl_application');
+const logger = require('../../../lib/utils/objects/logger');
 
 describe('ApplicationValidator', () => {
   let validator;
@@ -319,10 +325,19 @@ describe('ApplicationValidator', () => {
         });
       });
       context('with unknown options', () => {
-        it('should fail', () => {
-          expect(() =>
-            validator.validate(new JDLApplication({ config: { ...basicValidApplicationConfig, toto: 42 } }))
-          ).to.throw(/^Unrecognised application option name: toto\.$/);
+        let loggerDebug;
+        before(() => {
+          loggerDebug = sinon.spy(logger, 'debug');
+          new JDLApplication({ config: { ...basicValidApplicationConfig, toto: 42 } });
+        });
+        after(() => {
+          loggerDebug.restore();
+        });
+        it('it should send a debug message', () => {
+          expect(loggerDebug).to.have.been.calledOnce;
+          expect(loggerDebug.getCall(0).args[0]).to.equal(
+            'Unrecognized application option name and value: toto and 42'
+          );
         });
       });
       context('with unknown values', () => {


### PR DESCRIPTION
When some option type is missing we do not hard stop. Instead we log that the option type is missing and move on.

Fixes https://github.com/jhipster/generator-jhipster/issues/11532

Please make sure the below checklist is followed for Pull Requests.
  - [ ] Checks are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
