### PR TITLE
Implement add the possibility to allow blueprints to add custom keywords.

### DIFF
--- a/lib/converters/parsedJDLToJDLObject/application_converter.js
+++ b/lib/converters/parsedJDLToJDLObject/application_converter.js
@@ -38,7 +38,7 @@ function convertApplications(parsedApplications, configuration = {}, entityNames
   return parsedApplications.map(parsedApplication => {
     const applicationWithCustomValues = addCustomValuesToApplication(parsedApplication, configuration);
     const applicationEntityNames = resolveApplicationEntityNames(parsedApplication, entityNames);
-    const jdlApplication = createJDLApplication(applicationWithCustomValues.config);
+    const jdlApplication = createJDLApplication(applicationWithCustomValues.config, configuration.definitons);
     jdlApplication.addEntityNames(applicationEntityNames);
     const entityOptions = getEntityOptionsInApplication(parsedApplication);
     checkEntityNamesInOptions(

--- a/lib/core/generic_jdl_application_configuration_option.js
+++ b/lib/core/generic_jdl_application_configuration_option.js
@@ -17,26 +17,35 @@
  * limitations under the License.
  */
 
-module.exports = class JDLApplicationConfigurationOption {
-  /**
-   * Creates a new application option.
-   * @param {String} name - the option's name.
-   * @param {any} value - the option's value, can be virtually anything: a String, an Int, a boolean...
-   */
-  constructor(name, value) {
-    this.name = name;
-    this.value = value;
+const JDLApplicationConfigurationOption = require('./jdl_application_configuration_option');
+
+module.exports = class GenericJDLApplicationConfigurationOption extends JDLApplicationConfigurationOption {
+  constructor(name, value, valueShouldBeQuoted) {
+    super(name, Array.isArray(value) ? new Set(value) : value);
+    this.valueShouldBeQuoted = valueShouldBeQuoted;
   }
 
-  getName() {
-    return this.name;
+  isSet() {
+    return this.value instanceof Set;
   }
 
   getValue() {
+    if (this.isSet()) {
+      return Array.from(this.value);
+    }
     return this.value;
   }
 
   toString() {
-    return `${this.name} ${this.value}`;
+    let value;
+    if (this.isSet()) {
+      value = `[${this.getValue().join(', ')}]`;
+    } else {
+      value = `${this.value}`;
+      if (this.valueShouldBeQuoted) {
+        value = `"${value}"`;
+      }
+    }
+    return `${this.name} ${value}`;
   }
 };

--- a/lib/core/jdl_application.js
+++ b/lib/core/jdl_application.js
@@ -22,8 +22,8 @@ const JDLApplicationEntities = require('./jdl_application_entities');
 const JDLOptions = require('./jdl_options');
 
 module.exports = class JDLApplication {
-  constructor({ config = {}, entityNames = [] } = {}) {
-    this.config = createApplicationConfigurationFromObject(config);
+  constructor({ config = {}, entityNames = [], definitions } = {}) {
+    this.config = createApplicationConfigurationFromObject(config, definitions);
     this.entityNames = new JDLApplicationEntities(entityNames);
     this.options = new JDLOptions();
   }

--- a/lib/core/jdl_application_configuration.js
+++ b/lib/core/jdl_application_configuration.js
@@ -17,11 +17,12 @@
  * limitations under the License.
  */
 
-const { OptionNames } = require('./jhipster/application_options');
+const JCoreDefinitions = require('./jhipster');
 
 module.exports = class JDLApplicationConfiguration {
-  constructor(config = {}) {
+  constructor(config = {}, definitions = new JCoreDefinitions()) {
     this.options = {};
+    this.definitions = definitions;
   }
 
   hasOption(optionName) {
@@ -63,45 +64,22 @@ module.exports = class JDLApplicationConfiguration {
       return `${spaceBeforeConfigKeyword}config {}`;
     }
     const spaceBeforeOption = ' '.repeat(2 * indent);
-    const config = getFormattedConfigOptionsString(this.options, spaceBeforeOption);
+    const config = getFormattedConfigOptionsString(this.options, spaceBeforeOption, this.definitions);
     return `${spaceBeforeConfigKeyword}config {
 ${config}
 ${spaceBeforeConfigKeyword}}`;
   }
 };
 
-function getFormattedConfigOptionsString(options, indent) {
-  const filteredOptions = filterOutUnwantedOptions(options);
-  return Object.keys(filteredOptions)
+function getFormattedConfigOptionsString(options, indent, definitions) {
+  return Object.keys(options)
     .sort()
     .map(optionName => {
-      const option = options[optionName];
+      return options[optionName];
+    })
+    .filter(option => definitions.shouldOptionBeExported(option))
+    .map(option => {
       return `${indent}${option}`;
     })
     .join('\n');
-}
-
-function filterOutUnwantedOptions(options) {
-  return filterOutOptionsThatShouldNotBeExported(filterOutOptionsWithoutValues(options));
-}
-
-function filterOutOptionsWithoutValues(options) {
-  const filteredOptions = { ...options };
-  if (!(OptionNames.ENTITY_SUFFIX in options) || !options[OptionNames.ENTITY_SUFFIX].getValue()) {
-    delete filteredOptions[OptionNames.ENTITY_SUFFIX];
-  }
-  if (!(OptionNames.DTO_SUFFIX in options) || !options[OptionNames.DTO_SUFFIX].getValue()) {
-    delete filteredOptions[OptionNames.DTO_SUFFIX];
-  }
-  if (!(OptionNames.CLIENT_THEME_VARIANT in options) || !options[OptionNames.CLIENT_THEME_VARIANT].getValue()) {
-    delete filteredOptions[OptionNames.CLIENT_THEME_VARIANT];
-  }
-  return filteredOptions;
-}
-
-function filterOutOptionsThatShouldNotBeExported(options) {
-  const filteredOptions = { ...options };
-  delete filteredOptions[OptionNames.BLUEPRINTS];
-  delete filteredOptions[OptionNames.PACKAGE_FOLDER];
-  return filteredOptions;
 }

--- a/lib/core/jdl_application_configuration_factory.js
+++ b/lib/core/jdl_application_configuration_factory.js
@@ -22,32 +22,28 @@ const StringJDLApplicationConfigurationOption = require('./string_jdl_applicatio
 const IntegerJDLApplicationConfigurationOption = require('./integer_jdl_application_configuration_option');
 const BooleanJDLApplicationConfigurationOption = require('./boolean_jdl_application_configuration_option');
 const ListJDLApplicationConfigurationOption = require('./list_jdl_application_configuration_option');
-const {
-  getTypeForOption,
-  doesOptionExist,
-  OptionTypes,
-  shouldTheValueBeQuoted
-} = require('./jhipster/application_options');
-
-const logger = require('../utils/objects/logger');
+const GenericJDLApplicationConfigurationOption = require('./generic_jdl_application_configuration_option');
+const { getTypeForOption, OptionTypes, shouldTheValueBeQuoted } = require('./jhipster/application_options');
+const JCoreDefinitions = require('./jhipster');
 
 module.exports = { createApplicationConfigurationFromObject };
 
-function createApplicationConfigurationFromObject(configurationObject = {}) {
-  const configuration = new JDLApplicationConfiguration();
+function createApplicationConfigurationFromObject(configurationObject = {}, definitions = new JCoreDefinitions()) {
+  const configuration = new JDLApplicationConfiguration(undefined, definitions);
   Object.keys(configurationObject).forEach(optionName => {
     const optionValue = configurationObject[optionName];
-    if (!doesOptionExist(optionName, optionValue)) {
-      logger.debug(`Unrecognized application option name and value: ${optionName} and ${optionValue}`);
-      return;
-    }
-    configuration.setOption(createJDLConfigurationOption(optionName, optionValue));
+    configuration.setOption(createJDLConfigurationOption(optionName, optionValue, definitions));
   });
   return configuration;
 }
 
-function createJDLConfigurationOption(name, value) {
-  const type = getTypeForOption(name);
+function createJDLConfigurationOption(name, value, definitions) {
+  let type;
+  try {
+    type = getTypeForOption(name);
+  } catch (error) {
+    return new GenericJDLApplicationConfigurationOption(name, value, definitions.shouldTheValueBeQuoted(name, value));
+  }
   switch (type) {
     case OptionTypes.STRING:
       return new StringJDLApplicationConfigurationOption(name, value, shouldTheValueBeQuoted(name));
@@ -63,6 +59,6 @@ function createJDLConfigurationOption(name, value) {
       // If this is the case then an option's type isn't one of the cases
       // If there's a new option type, then you should handle it in the switch.
       // If there's no new option type, then you may have made a mistake.
-      throw new Error(`Unrecognized option type: ${type}.`);
+      throw new Error(`Unrecognized option type: ${type} for option ${name}.`);
   }
 }

--- a/lib/core/jdl_application_factory.js
+++ b/lib/core/jdl_application_factory.js
@@ -34,27 +34,25 @@ module.exports = {
 /**
  * Creates a JDL application from a passed configuration.
  * @param {Object} config - the application configuration.
+ * @param {JCoreDefinitions} definitions - the aplication definitions.
  * @returns {JDLApplication} the created JDL application.
  */
-function createJDLApplication(config = {}) {
+function createJDLApplication(config = {}, definitions) {
   const baseConfig = getDefaultConfigForNewApplication(config);
+  let appConfig;
   switch (config.applicationType) {
     case ApplicationTypes.MICROSERVICE:
-      return new JDLApplication({
-        config: getConfigForMicroserviceApplication(baseConfig)
-      });
+      appConfig = getConfigForMicroserviceApplication(baseConfig);
+      break;
     case ApplicationTypes.GATEWAY:
-      return new JDLApplication({
-        config: getConfigForGatewayApplication(baseConfig)
-      });
+      appConfig = getConfigForGatewayApplication(baseConfig);
+      break;
     case ApplicationTypes.UAA:
-      return new JDLApplication({
-        config: getConfigForUAAApplication(baseConfig)
-      });
+      appConfig = getConfigForUAAApplication(baseConfig);
+      break;
     case ApplicationTypes.MONOLITH:
     default:
-      return new JDLApplication({
-        config: getConfigForMonolithApplication(baseConfig)
-      });
+      appConfig = getConfigForMonolithApplication(baseConfig);
   }
+  return new JDLApplication({ config: appConfig, definitions });
 }

--- a/lib/core/jhipster/application_options.js
+++ b/lib/core/jhipster/application_options.js
@@ -267,13 +267,19 @@ const optionTypes = {
 const QuotedOptionNames = [optionNames.JHIPSTER_VERSION, optionNames.REMEMBER_ME_KEY, optionNames.JWT_SECRET_KEY];
 
 module.exports = {
+  /** @deprecated */
   OptionTypes: ApplicationOptionTypes,
+  OptionTypes_: optionTypes,
   OptionNames: optionNames,
   OptionValues: optionValues,
   QuotedOptionNames,
+  /** @deprecated */
   getTypeForOption,
+  /** @deprecated */
   doesOptionExist,
+  /** @deprecated */
   doesOptionValueExist,
+  /** @deprecated */
   shouldTheValueBeQuoted
 };
 

--- a/lib/core/jhipster/build_in_definitions.js
+++ b/lib/core/jhipster/build_in_definitions.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { OptionTypes_, OptionNames, QuotedOptionNames, OptionValues } = require('./application_options');
+const databaseTypes = require('./database_types');
+
+const supportedDatabases = { ...databaseTypes };
+
+delete supportedDatabases.isSql;
+
+const sqlDatabases = [
+  supportedDatabases.SQL,
+  supportedDatabases.MYSQL,
+  supportedDatabases.POSTGRESQL,
+  supportedDatabases.MARIADB,
+  supportedDatabases.ORACLE,
+  supportedDatabases.MSSQL
+];
+
+const cannotMixProdDev = [
+  supportedDatabases.MONGODB,
+  supportedDatabases.COUCHBASE,
+  supportedDatabases.CASSANDRA,
+  supportedDatabases.NEO4J
+];
+
+const prodSqlDatabases = [
+  supportedDatabases.MYSQL,
+  supportedDatabases.POSTGRESQL,
+  supportedDatabases.MARIADB,
+  supportedDatabases.ORACLE,
+  supportedDatabases.MSSQL
+];
+
+const databases = { no: {} };
+
+sqlDatabases.forEach(type => {
+  databases[type] = databases[type] || {};
+  databases[type].sql = true;
+});
+
+cannotMixProdDev.forEach(type => {
+  databases[type] = databases[type] || {};
+  databases[type].cannotMixProdDev = true;
+});
+
+prodSqlDatabases.forEach(type => {
+  databases[type] = databases[type] || {};
+  databases[type].sql = true;
+  databases[type].prod = true;
+});
+
+[OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Memory, OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Disk].forEach(
+  type => {
+    databases[type] = databases[type] || {};
+    databases[type].sql = true;
+    databases[type].devOnly = true;
+  }
+);
+
+const applicationOptions = {};
+
+const getOrCreateDefinition = optionName => {
+  const optionDefinition = (applicationOptions[optionName] = applicationOptions[optionName] || {});
+  optionDefinition.label = optionName;
+  return optionDefinition;
+};
+
+const getOrCreateJDLDefinition = optionName => {
+  const optionDefinition = getOrCreateDefinition(optionName);
+  const jdlDefinition = (optionDefinition.jdl = optionDefinition.jdl || {});
+  return jdlDefinition;
+};
+
+Object.entries(OptionNames).forEach(([_optionIdentifier, optionName]) => {
+  getOrCreateDefinition(optionName);
+});
+
+Object.entries(OptionTypes_).forEach(([optionName, optionType]) => {
+  getOrCreateDefinition(optionName).type = optionType.type;
+});
+
+Object.entries(OptionValues).forEach(([optionName, optionValues]) => {
+  getOrCreateDefinition(optionName).values = optionValues;
+});
+
+QuotedOptionNames.forEach(optionName => {
+  getOrCreateJDLDefinition(optionName).quoted = true;
+});
+
+[OptionNames.ENTITY_SUFFIX, OptionNames.DTO_SUFFIX, OptionNames.CLIENT_THEME_VARIANT].forEach(optionName => {
+  getOrCreateJDLDefinition(optionName).omitOnNegativeValue = true;
+});
+
+[OptionNames.PACKAGE_FOLDER, OptionNames.BLUEPRINTS].forEach(optionName => {
+  getOrCreateJDLDefinition(optionName).alwaysOmit = true;
+});
+
+module.exports = {
+  applicationOptions,
+  databases
+};

--- a/lib/core/jhipster/index.js
+++ b/lib/core/jhipster/index.js
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const _ = require('lodash');
+const BUILD_IN_DEFINITIONS = require('./build_in_definitions');
+const logger = require('../../utils/objects/logger');
+const { SQL } = require('./database_types');
+
+const DEFINITION_STRUCTURE = {
+  applicationOptions: {},
+  databases: {}
+};
+
+class JCoreDefinitions {
+  static get DEFINITIONS() {
+    return _.cloneDeep(BUILD_IN_DEFINITIONS);
+  }
+
+  constructor(definitions = JCoreDefinitions.DEFINITIONS) {
+    this._definitions = _.merge({}, DEFINITION_STRUCTURE, definitions);
+  }
+
+  extendDefinitions(additionalDefinitions) {
+    if (!Array.isArray(additionalDefinitions)) {
+      additionalDefinitions = [additionalDefinitions];
+    }
+    _.merge(this._definitions, ...additionalDefinitions);
+  }
+
+  /**
+   * Returns the option's type, one of string, boolean, list or integer.
+   * @param {String} optionName - the option's name.
+   * @returns {String} the option's type.
+   */
+  getTypeForOption(optionName) {
+    if (!optionName) {
+      throw new Error('A name has to be passed to get the option type.');
+    }
+    const optionSpec = this._definitions.applicationOptions[optionName];
+    if (!optionSpec) {
+      throw new Error(`Unrecognised application option name: ${optionName}.`);
+    }
+    return optionSpec.type;
+  }
+
+  /**
+   * Checks whether the option value exists for the passed option name.
+   * @param {String} name - the option name.
+   * @param {String|Boolean|Number|Array} value - the option value.
+   * @returns {Boolean} whether the option value exists for the name.
+   */
+  doesOptionValueExist(optionName, value) {
+    if (!this.doesOptionExist(optionName)) {
+      return false;
+    }
+    const optionValues = this._definitions.applicationOptions[optionName].values;
+    return optionValues && optionValues[value] != null;
+  }
+
+  /**
+   * Checks whether the option's exists.
+   * @param {String} optionName - the option's name.
+   * @returns {Boolean} the option's existence.
+   */
+  doesOptionExist(optionName) {
+    return !!optionName && this._definitions.applicationOptions[optionName];
+  }
+
+  /**
+   * Checks whether the option's should be exported to jdl.
+   * @param {JDLApplicationConfigurationOption} optionName - the option's name.
+   * @returns {Boolean|Undefined} the option's existence.
+   */
+  shouldOptionBeExported(option) {
+    const shouldBeExported = this.doesOptionExist(option.getName(), option.getValue());
+    if (!shouldBeExported) {
+      logger.debug(`Unrecognized application option name and value: ${option.getName()} and ${option.getValue()}`);
+      // Config is not contained at definitions.
+      return undefined;
+    }
+    const optionSpec = this._definitions.applicationOptions[option.getName()];
+    if (optionSpec.jdl && optionSpec.jdl.alwaysOmit) {
+      return false;
+    }
+    if (optionSpec.jdl && optionSpec.jdl.omitOnNegativeValue && !option.getValue()) {
+      return false;
+    }
+    return shouldBeExported;
+  }
+
+  shouldTheValueBeQuoted(optionName, value) {
+    if (!optionName) {
+      return false;
+    }
+    if (value !== undefined && !(value instanceof Set) && !/^[A-Za-z][A-Za-z0-9-_]*$/.test(`${value}`)) {
+      return true;
+    }
+    const optionSpec = this._definitions.applicationOptions[optionName];
+    return optionSpec && optionSpec.jdl && optionSpec.jdl.quoted;
+  }
+
+  /* DATABASE */
+  databaseIsSql(type) {
+    const databaseSpec = this._definitions.databases[type];
+    return !!(databaseSpec && databaseSpec.sql);
+  }
+
+  _prodSqlDatabases() {
+    return Object.entries(this._definitions.databases)
+      .filter(([_name, spec]) => {
+        return spec.prod;
+      })
+      .map(([name, _spec]) => name);
+  }
+
+  _cannotMixProdDevDatabases() {
+    return Object.entries(this._definitions.databases)
+      .filter(([_name, spec]) => {
+        return spec.cannotMixProdDev;
+      })
+      .map(([name, _spec]) => name);
+  }
+
+  _devSqlDatabases() {
+    return Object.entries(this._definitions.databases)
+      .filter(([_name, spec]) => {
+        return spec.devOnly;
+      })
+      .map(([name, _spec]) => name);
+  }
+
+  assertDatabasesAreAllowed(databaseType, prodDatabaseType, devDatabaseType, config = {}) {
+    if (!databaseType && !prodDatabaseType && !devDatabaseType) {
+      return;
+    }
+    const databaseTypeSpec = this._definitions.databases[databaseType];
+    if (!databaseTypeSpec) {
+      throw new Error(`Database type ${databaseType} is not supported`);
+    }
+    const prodDatabaseSpec = this._definitions.databases[prodDatabaseType];
+    if (!prodDatabaseSpec) {
+      throw new Error(`Prod database type ${prodDatabaseType} is not supported`);
+    }
+    const devDatabaseSpec = this._definitions.databases[devDatabaseType];
+    if (!devDatabaseSpec) {
+      throw new Error(`Dev database type ${devDatabaseType} is not supported`);
+    }
+    if (databaseType === SQL) {
+      if (!prodDatabaseSpec.prod) {
+        throw new Error(
+          `Only ${formatValueList(
+            this._prodSqlDatabases()
+          )} are allowed as prodDatabaseType values for databaseType 'sql'.`
+        );
+      }
+      if (prodDatabaseType !== devDatabaseType && !devDatabaseSpec.devOnly) {
+        throw new Error(
+          `Database '${devDatabaseType}' is not allowed as dev database for '${prodDatabaseType}'. Only ${formatValueList(
+            this._devSqlDatabases(prodDatabaseType).concat([prodDatabaseType])
+          )} are allowed as devDatabaseType values.`
+        );
+      }
+      if (!devDatabaseSpec.sql || !prodDatabaseSpec.sql) {
+        throw new Error(
+          `Both 'prodDatabaseType=${prodDatabaseType}' and 'devDatabaseType=${devDatabaseType}' must be sql.`
+        );
+      }
+      return;
+    }
+    if (databaseTypeSpec.cannotMixProdDev) {
+      if (databaseType !== devDatabaseType || databaseType !== prodDatabaseType) {
+        throw new Error(
+          `When the databaseType is either ${formatValueList(
+            this._cannotMixProdDevDatabases()
+          )}, the devDatabaseType and prodDatabaseType must be the same.`
+        );
+      }
+      if (config.enabledHibernateCache) {
+        throw new Error(
+          `An application having ${databaseType} as database type can't have the hibernate cache enabled.`
+        );
+      }
+    }
+  }
+}
+
+function formatValueList(list) {
+  return list.map(item => `'${item}'`).join(', ');
+}
+
+module.exports = JCoreDefinitions;

--- a/lib/dsl/lexer/application_tokens.js
+++ b/lib/dsl/lexer/application_tokens.js
@@ -27,6 +27,7 @@ const {
 const applicationConfigCategoryToken = createTokenFromConfig({ name: 'CONFIG_KEY', pattern: Lexer.NA });
 
 const applicationConfigTokens = [
+  { name: 'BLUEPRINT_CONFIGS', pattern: /\w+:\w+/ },
   { name: 'BASE_NAME', pattern: 'baseName' },
   { name: 'BLUEPRINT', pattern: 'blueprint' },
   { name: 'EMBEDDABLE_LAUNCH_SCRIPT', pattern: 'embeddableLaunchScript' },

--- a/lib/dsl/self_checks/parsing_system_checker.js
+++ b/lib/dsl/self_checks/parsing_system_checker.js
@@ -27,7 +27,8 @@ module.exports = {
 
 function checkTokens(allDefinedTokens, rules) {
   const usedTokens = getUsedTokens(rules);
-  const unusedTokens = getUselessTokens(usedTokens, allDefinedTokens);
+  let unusedTokens = getUselessTokens(usedTokens, allDefinedTokens);
+  unusedTokens = unusedTokens.filter(tokenType => tokenType.name !== 'BLUEPRINT_CONFIGS');
   if (unusedTokens.length !== 0) {
     const unusedTokenTypeNames = unusedTokens.map(tokenType => tokenType.name);
     throw Error(`Unused token definitions found: [ ${unusedTokenTypeNames.join(', ')} ]`);

--- a/lib/dsl/validator.js
+++ b/lib/dsl/validator.js
@@ -47,6 +47,11 @@ const JWT_SECRET_KEY_PATTERN = /^\S+$/;
 const NUMERIC = /^\d$/;
 
 const configPropsValidations = {
+  BLUEPRINT_CONFIGS: {
+    type: 'NAME',
+    pattern: ALPHANUMERIC_UNDERSCORE,
+    msg: 'blueprint custom property'
+  },
   APPLICATION_TYPE: {
     type: 'NAME',
     pattern: ALPHABETIC_LOWER,

--- a/lib/exporters/jhipster_application_exporter.js
+++ b/lib/exporters/jhipster_application_exporter.js
@@ -33,12 +33,15 @@ module.exports = {
  * @param applications the applications to exporters (key: application name, value: a JDLApplication).
  * @return object[] exported applications in their final form.
  */
-function exportApplications(applications) {
+function exportApplications(applications, options = {}) {
+  const { skipValidation } = options;
   if (!applications) {
     throw new Error('Applications have to be passed to be exported.');
   }
   return Object.values(applications).map(application => {
-    checkForErrors(application);
+    if (!skipValidation) {
+      checkForErrors(application);
+    }
     const exportableApplication = setUpApplicationStructure(application);
     writeApplicationFileForMultipleApplications(exportableApplication);
     return exportableApplication;
@@ -48,8 +51,8 @@ function exportApplications(applications) {
 /**
  * Alias of exportApplication.
  */
-function exportApplicationInCurrentDirectory(application, configuration = {}) {
-  return exportApplication(application, configuration);
+function exportApplicationInCurrentDirectory(application, configuration = {}, options) {
+  return exportApplication(application, configuration, options);
 }
 
 /**
@@ -60,8 +63,10 @@ function exportApplicationInCurrentDirectory(application, configuration = {}) {
  * @param {Integer} configuration.creationTimestampConfig - date representation to be written to creationTimestamp at .yo-rc.json.
  * @return {Object} the exported application in its final form.
  */
-function exportApplication(application, configuration = {}) {
-  checkForErrors(application);
+function exportApplication(application, configuration = {}, options = {}) {
+  if (!options.skipValidation) {
+    checkForErrors(application);
+  }
   const exportableApplication = setUpApplicationStructure(application, configuration);
   if (!configuration.skipYoRcGeneration) {
     writeConfigFile(exportableApplication);

--- a/lib/jdl/jdl_importer.js
+++ b/lib/jdl/jdl_importer.js
@@ -24,6 +24,7 @@ const JHipsterApplicationExporter = require('../exporters/jhipster_application_e
 const JHipsterDeploymentExporter = require('../exporters/jhipster_deployment_exporter');
 const JHipsterEntityExporter = require('../exporters/jhipster_entity_exporter');
 const BusinessErrorChecker = require('../validators/business_error_checker');
+const JCoreDefinitions = require('../core/jhipster');
 
 module.exports = {
   createImporterFromContent,
@@ -101,16 +102,21 @@ function makeJDLImporter(content, configuration) {
      *          - exportedApplications: the exported applications, or an empty list
      *          - exportedEntities: the exported entities, or an empty list
      */
-    import: () => {
+    import: (getAdditionalDefinitions = () => {}) => {
       configuration.creationTimestampConfig = getCreationTimestampToUse(configuration.creationTimestamp);
-      const jdlObject = getJDLObject(content, configuration);
-      checkForErrors(jdlObject, configuration);
+      const definitions = new JCoreDefinitions(configuration.definitions);
+      const jdlObject = getJDLObject(content, configuration, definitions);
+      const additionalDefinitions = getAdditionalDefinitions();
+      if (additionalDefinitions) {
+        definitions.extendDefinitions(additionalDefinitions);
+      }
+      checkForErrors(jdlObject, configuration, definitions);
       if (jdlObject.getApplicationQuantity() === 0 && jdlObject.getEntityQuantity() > 0) {
         importState.exportedEntities = importOnlyEntities(jdlObject, configuration);
       } else if (jdlObject.getApplicationQuantity() === 1) {
-        importState = importOneApplicationAndEntities(jdlObject, configuration);
+        importState = importOneApplicationAndEntities(jdlObject, configuration, { skipValidation: true });
       } else {
-        importState = importApplicationsAndEntities(jdlObject, configuration);
+        importState = importApplicationsAndEntities(jdlObject, configuration, { skipValidation: true });
       }
       if (jdlObject.getDeploymentQuantity()) {
         importState.exportedDeployments = importDeployments(jdlObject.deployments);
@@ -137,7 +143,7 @@ function parseFiles(files) {
   return JDLReader.parseFromFiles(files);
 }
 
-function getJDLObject(parsedJDLContent, configuration) {
+function getJDLObject(parsedJDLContent, configuration, definitions) {
   let baseName = configuration.applicationName;
   let applicationType = configuration.applicationType;
   let generatorVersion = configuration.generatorVersion;
@@ -154,6 +160,7 @@ function getJDLObject(parsedJDLContent, configuration) {
 
   return DocumentParser.parseFromConfigurationObject({
     parsedContent: parsedJDLContent,
+    definitions,
     applicationType,
     applicationName: baseName,
     generatorVersion,
@@ -162,7 +169,7 @@ function getJDLObject(parsedJDLContent, configuration) {
   });
 }
 
-function checkForErrors(jdlObject, configuration) {
+function checkForErrors(jdlObject, configuration, definitions) {
   let applicationType = configuration.applicationType;
   let databaseType = configuration.databaseType;
   let skippedUserManagement = false;
@@ -171,11 +178,15 @@ function checkForErrors(jdlObject, configuration) {
     databaseType = configuration.application['generator-jhipster'].databaseType;
     skippedUserManagement = configuration.application['generator-jhipster'].skipUserManagement;
   }
-  const errorChecker = new BusinessErrorChecker(jdlObject, {
-    applicationType,
-    databaseType,
-    skippedUserManagement
-  });
+  const errorChecker = new BusinessErrorChecker(
+    jdlObject,
+    {
+      applicationType,
+      databaseType,
+      skippedUserManagement
+    },
+    definitions
+  );
   errorChecker.checkForErrors();
 }
 
@@ -200,7 +211,7 @@ function importOnlyEntities(jdlObject, configuration) {
   return exportJSONEntities(jsonEntities, configuration);
 }
 
-function importOneApplicationAndEntities(jdlObject, configuration) {
+function importOneApplicationAndEntities(jdlObject, configuration, options) {
   const { creationTimestamp, skipEntityFilesGeneration } = configuration;
 
   const importState = {
@@ -209,7 +220,11 @@ function importOneApplicationAndEntities(jdlObject, configuration) {
     exportedDeployments: []
   };
   importState.exportedApplications.push(
-    JHipsterApplicationExporter.exportApplicationInCurrentDirectory(jdlObject.getApplications()[0], configuration)
+    JHipsterApplicationExporter.exportApplicationInCurrentDirectory(
+      jdlObject.getApplications()[0],
+      configuration,
+      options
+    )
   );
   const jdlApplication = jdlObject.getApplications()[0];
   const applicationName = jdlApplication.getConfigurationOptionValue('baseName');
@@ -230,7 +245,7 @@ function importOneApplicationAndEntities(jdlObject, configuration) {
   return importState;
 }
 
-function importApplicationsAndEntities(jdlObject, configuration) {
+function importApplicationsAndEntities(jdlObject, configuration, options) {
   const { creationTimestamp, skipEntityFilesGeneration } = configuration;
 
   const importState = {
@@ -239,7 +254,7 @@ function importApplicationsAndEntities(jdlObject, configuration) {
     exportedDeployments: []
   };
 
-  importState.exportedApplications = JHipsterApplicationExporter.exportApplications(jdlObject.applications);
+  importState.exportedApplications = JHipsterApplicationExporter.exportApplications(jdlObject.applications, options);
   const entitiesPerApplicationMap = JDLWithApplicationsToJSONConverter.convert({
     jdlObject,
     creationTimestamp

--- a/lib/validators/application_validator.js
+++ b/lib/validators/application_validator.js
@@ -19,42 +19,25 @@
 const Validator = require('./validator');
 const UnaryOptionValidator = require('./unary_option_validator');
 const BinaryOptionValidator = require('./binary_option_validator');
-const {
-  OptionNames,
-  OptionValues,
-  getTypeForOption,
-  doesOptionExist,
-  doesOptionValueExist
-} = require('../core/jhipster/application_options');
 const { UAA, MICROSERVICE } = require('../core/jhipster/application_types');
-const {
-  COUCHBASE,
-  NEO4J,
-  CASSANDRA,
-  MONGODB,
-  MARIADB,
-  MSSQL,
-  MYSQL,
-  ORACLE,
-  POSTGRESQL,
-  SQL
-} = require('../core/jhipster/database_types');
+const { CASSANDRA } = require('../core/jhipster/database_types');
 const { Options } = require('../core/jhipster/binary_options');
+const JCoreDefinitions = require('../core/jhipster');
 
 class ApplicationValidator extends Validator {
   constructor() {
     super('application', []);
   }
 
-  validate(jdlApplication) {
+  validate(jdlApplication, definitions = new JCoreDefinitions()) {
     if (!jdlApplication) {
       throw new Error('An application must be passed to be validated.');
     }
     checkRequiredOptionsAreSet(jdlApplication);
     checkBaseNameAgainstApplicationType(jdlApplication);
     checkLanguageOptions(jdlApplication);
-    checkForValidValues(jdlApplication);
-    checkForInvalidDatabaseCombinations(jdlApplication);
+    checkForValidValues(jdlApplication, definitions);
+    checkForInvalidDatabaseCombinations(jdlApplication, definitions);
     checkApplicationOptions(jdlApplication);
   }
 }
@@ -95,7 +78,7 @@ function checkLanguageOptions(jdlApplication) {
   }
 }
 
-function checkForValidValues(jdlApplication) {
+function checkForValidValues(jdlApplication, definitions) {
   const optionsToIgnore = [
     'baseName',
     'packageName',
@@ -118,139 +101,96 @@ function checkForValidValues(jdlApplication) {
     if (optionsToIgnore.includes(option.name)) {
       return;
     }
-    checkForUnknownApplicationOption(option);
-    checkForBooleanValue(option);
-    checkSpecificOptions(option);
+    checkForUnknownApplicationOption(definitions, option);
+    checkForBooleanValue(definitions, option);
+    checkSpecificOptions(definitions, option);
   });
 }
 
-function checkForUnknownApplicationOption(option) {
-  if (!doesOptionExist(option.name)) {
+function checkForUnknownApplicationOption(definitions, option) {
+  if (!definitions.doesOptionExist(option.name)) {
     throw new Error(`Unknown application option '${option.name}'.`);
   }
 }
 
-function checkForBooleanValue(option) {
-  if (getTypeForOption(option.name) === 'boolean' && typeof option.getValue() !== 'boolean') {
+function checkForBooleanValue(definitions, option) {
+  if (definitions.getTypeForOption(option.name) === 'boolean' && typeof option.getValue() !== 'boolean') {
     throw new Error(`Expected a boolean value for option '${option.name}'`);
   }
 }
 
-function checkSpecificOptions(option) {
+function checkSpecificOptions(definitions, option) {
   switch (option.name) {
     case 'clientTheme':
     case 'clientThemeVariant':
       return;
     case 'testFrameworks':
-      checkTestFrameworkValues(option.getValue());
+      checkTestFrameworkValues(definitions, option.getValue());
       break;
     case 'databaseType':
-      checkDatabaseTypeValue(option.getValue());
+      checkDatabaseTypeValue(definitions, option.getValue());
       break;
     case 'devDatabaseType':
-      checkDevDatabaseTypeValue(option.getValue());
+      checkDevDatabaseTypeValue(definitions, option.getValue());
       break;
     case 'prodDatabaseType':
-      checkProdDatabaseTypeValue(option.getValue());
+      checkProdDatabaseTypeValue(definitions, option.getValue());
       break;
     default:
-      checkForUnknownValue(option);
+      checkForUnknownValue(definitions, option);
   }
 }
 
-function checkTestFrameworkValues(values) {
+function checkTestFrameworkValues(jdlApplication, values) {
   if (Object.keys(values).length === 0) {
     return;
   }
   values.forEach(value => {
-    if (!doesOptionValueExist('testFrameworks', value)) {
+    if (!jdlApplication.doesOptionValueExist('testFrameworks', value)) {
       throw new Error(`Unknown value '${value}' for option 'testFrameworks'.`);
     }
   });
 }
 
-function checkDatabaseTypeValue(value) {
-  if (!doesOptionValueExist('databaseType', value)) {
+function checkDatabaseTypeValue(jdlApplication, value) {
+  if (!jdlApplication.doesOptionValueExist('databaseType', value)) {
     throw new Error(`Unknown value '${value}' for option 'databaseType'.`);
   }
 }
 
-function checkDevDatabaseTypeValue(value) {
+function checkDevDatabaseTypeValue(jdlApplication, value) {
   if (
-    !doesOptionValueExist('databaseType', value) &&
-    !doesOptionValueExist('devDatabaseType', value) &&
-    !doesOptionValueExist('prodDatabaseType', value)
+    !jdlApplication.doesOptionValueExist('databaseType', value) &&
+    !jdlApplication.doesOptionValueExist('devDatabaseType', value) &&
+    !jdlApplication.doesOptionValueExist('prodDatabaseType', value)
   ) {
     throw new Error(`Unknown value '${value}' for option 'devDatabaseType'.`);
   }
 }
 
-function checkProdDatabaseTypeValue(value) {
-  if (!doesOptionValueExist('databaseType', value) && !doesOptionValueExist('prodDatabaseType', value)) {
+function checkProdDatabaseTypeValue(jdlApplication, value) {
+  if (
+    !jdlApplication.doesOptionValueExist('databaseType', value) &&
+    !jdlApplication.doesOptionValueExist('prodDatabaseType', value)
+  ) {
     throw new Error(`Unknown value '${value}' for option 'prodDatabaseType'.`);
   }
 }
 
-function checkForUnknownValue(option) {
-  if (getTypeForOption(option.name) !== 'boolean' && !doesOptionValueExist(option.name, option.getValue())) {
+function checkForUnknownValue(definitions, option) {
+  const optionType = definitions.getTypeForOption(option.name);
+  if (optionType !== 'boolean' && !definitions.doesOptionValueExist(option.name, option.getValue())) {
     throw new Error(`Unknown option value '${option.getValue()}' for option '${option.name}'.`);
   }
 }
 
-function checkForInvalidDatabaseCombinations(jdlApplication) {
+function checkForInvalidDatabaseCombinations(jdlApplication, definitions) {
   const databaseType = jdlApplication.getConfigurationOptionValue('databaseType');
   const devDatabaseType = jdlApplication.getConfigurationOptionValue('devDatabaseType');
   const prodDatabaseType = jdlApplication.getConfigurationOptionValue('prodDatabaseType');
   const enabledHibernateCache = jdlApplication.getConfigurationOptionValue('enableHibernateCache');
 
-  if (databaseType === SQL) {
-    if (![MYSQL, POSTGRESQL, MARIADB, ORACLE, MSSQL].includes(prodDatabaseType)) {
-      throw new Error(
-        `Only ${formatValueList([
-          MYSQL,
-          POSTGRESQL,
-          MARIADB,
-          ORACLE,
-          MSSQL
-        ])} are allowed as prodDatabaseType values for databaseType 'sql'.`
-      );
-    }
-    if (
-      ![
-        OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Memory,
-        OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Disk,
-        prodDatabaseType
-      ].includes(devDatabaseType)
-    ) {
-      throw new Error(
-        `Only ${formatValueList([
-          OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Memory,
-          OptionValues[OptionNames.DEV_DATABASE_TYPE].h2Disk,
-          prodDatabaseType
-        ])} are allowed as devDatabaseType values for databaseType 'sql'.`
-      );
-    }
-    return;
-  }
-  if ([MONGODB, COUCHBASE, CASSANDRA, NEO4J].includes(databaseType)) {
-    if (databaseType !== devDatabaseType || databaseType !== prodDatabaseType) {
-      throw new Error(
-        `When the databaseType is either ${formatValueList([
-          MONGODB,
-          COUCHBASE,
-          CASSANDRA,
-          NEO4J
-        ])}, the devDatabaseType and prodDatabaseType must be the same.`
-      );
-    }
-    if (enabledHibernateCache) {
-      throw new Error(`An application having ${databaseType} as database type can't have the hibernate cache enabled.`);
-    }
-  }
-}
-
-function formatValueList(list) {
-  return list.map(item => `'${item}'`).join(', ');
+  definitions.assertDatabasesAreAllowed(databaseType, prodDatabaseType, devDatabaseType, { enabledHibernateCache });
 }
 
 function checkApplicationOptions(jdlApplication) {

--- a/lib/validators/business_error_checker.js
+++ b/lib/validators/business_error_checker.js
@@ -27,6 +27,7 @@ const FieldValidator = require('./field_validator');
 const ValidationValidator = require('./validation_validator');
 const EnumValidator = require('./enum_validator');
 const RelationshipValidator = require('./relationship_validator');
+const JCoreDefinitions = require('../core/jhipster');
 const { OptionNames } = require('../core/jhipster/application_options');
 const { GATEWAY } = require('../core/jhipster/application_types');
 const FieldTypes = require('../core/jhipster/field_types');
@@ -46,10 +47,11 @@ class BusinessErrorChecker {
    * @param {String} applicationSettings.databaseType - the DB type.
    * @param {Boolean} applicationSettings.skippedUserManagement - whether user management is skipped.
    */
-  constructor(jdlObject, applicationSettings) {
+  constructor(jdlObject, applicationSettings, definitions = new JCoreDefinitions()) {
     if (!jdlObject) {
       throw new Error('A JDL object must be passed to check for business errors.');
     }
+    this.definitions = definitions;
     this.jdlObject = jdlObject;
     this.applicationSettings = applicationSettings || {};
     this.typeCheckingFunction = null;
@@ -77,7 +79,7 @@ class BusinessErrorChecker {
     }
     const validator = new ApplicationValidator();
     this.jdlObject.forEachApplication(jdlApplication => {
-      validator.validate(jdlApplication);
+      validator.validate(jdlApplication, this.definitions);
     });
   }
 

--- a/test/spec/core/generic_jdl_application_configuration_option.js
+++ b/test/spec/core/generic_jdl_application_configuration_option.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-new, no-unused-expressions */
+const { expect } = require('chai');
+const GenericJDLApplicationConfigurationOption = require('../../../lib/core/generic_jdl_application_configuration_option');
+
+describe('GenericJDLApplicationConfigurationOption', () => {
+  describe('toString', () => {
+    context('when passing string', () => {
+      let jdlConfigurationOption;
+      before(() => {
+        jdlConfigurationOption = new GenericJDLApplicationConfigurationOption('foo', 'bar');
+      });
+      it('should return', () => {
+        expect(jdlConfigurationOption.toString()).to.be.equal('foo bar');
+      });
+    });
+
+    context('when passing value and quote option', () => {
+      let jdlConfigurationOption;
+
+      before(() => {
+        jdlConfigurationOption = new GenericJDLApplicationConfigurationOption('foo', '.bar', true);
+      });
+      it('should add quotes', () => {
+        expect(jdlConfigurationOption.toString()).to.be.equal('foo ".bar"');
+      });
+    });
+
+    context('when passing array', () => {
+      let jdlConfigurationOption;
+
+      before(() => {
+        jdlConfigurationOption = new GenericJDLApplicationConfigurationOption('foo', ['bar']);
+      });
+      it('should add brackets', () => {
+        expect(jdlConfigurationOption.toString()).to.be.equal('foo [bar]');
+      });
+    });
+  });
+});

--- a/test/spec/core/jdl_application_configuration_factory.spec.js
+++ b/test/spec/core/jdl_application_configuration_factory.spec.js
@@ -17,7 +17,9 @@
  * limitations under the License.
  */
 
+/* eslint-disable no-unused-expressions */
 const { expect } = require('chai');
+
 const JDLApplicationConfiguration = require('../../../lib/core/jdl_application_configuration');
 const StringJDLApplicationConfigurationOption = require('../../../lib/core/string_jdl_application_configuration_option');
 const IntegerJDLApplicationConfigurationOption = require('../../../lib/core/integer_jdl_application_configuration_option');
@@ -109,6 +111,17 @@ describe('JDLApplicationConfigurationFactory', () => {
 
         it('should create it', () => {
           expect(createdConfiguration).to.deep.equal(expectedConfiguration);
+        });
+      });
+      context('containing an unknown configuration', () => {
+        let config;
+
+        before(() => {
+          config = createApplicationConfigurationFromObject({ toto: 42 });
+        });
+        it('should add the generic field', () => {
+          expect(config.options.toto).to.be.an('object');
+          expect(config.options.toto.name).to.equal('toto');
         });
       });
     });

--- a/test/spec/core/jhipster/database_types.spec.js
+++ b/test/spec/core/jhipster/database_types.spec.js
@@ -19,8 +19,8 @@
 /* eslint-disable no-unused-expressions */
 
 const { expect } = require('chai');
+const JCoreDefinitions = require('../../../../lib/core/jhipster');
 const {
-  isSql,
   CASSANDRA,
   COUCHBASE,
   MARIADB,
@@ -34,17 +34,19 @@ const {
 } = require('../../../../lib/core/jhipster/database_types');
 
 describe('DatabaseTypes', () => {
-  describe('isSql', () => {
+  const builtInDefinitions = new JCoreDefinitions();
+
+  describe('databaseIsSql', () => {
     context('when not passing anything', () => {
       it('should return false', () => {
-        expect(isSql()).to.be.false;
+        expect(builtInDefinitions.databaseIsSql()).to.be.false;
       });
     });
     context('when passing a SQL database type', () => {
       [SQL, MYSQL, POSTGRESQL, ORACLE, MARIADB, MSSQL].forEach(databaseType => {
         context(`such as ${databaseType}`, () => {
           it('should return true', () => {
-            expect(isSql(databaseType)).to.be.true;
+            expect(builtInDefinitions.databaseIsSql(databaseType)).to.be.true;
           });
         });
       });
@@ -53,7 +55,7 @@ describe('DatabaseTypes', () => {
       [MONGODB, CASSANDRA, COUCHBASE, NO].forEach(databaseType => {
         context(`such as ${databaseType}`, () => {
           it('should return false', () => {
-            expect(isSql(databaseType)).to.be.false;
+            expect(builtInDefinitions.databaseIsSql(databaseType)).to.be.false;
           });
         });
       });

--- a/test/spec/exceptions/application_validator.spec.js
+++ b/test/spec/exceptions/application_validator.spec.js
@@ -18,12 +18,7 @@
  */
 
 /* eslint-disable no-new, no-unused-expressions */
-const chai = require('chai');
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
-
-chai.use(sinonChai);
-const { expect } = chai;
+const { expect } = require('chai');
 
 const ApplicationValidator = require('../../../lib/validators/application_validator');
 
@@ -43,7 +38,6 @@ const BinaryOptions = require('../../../lib/core/jhipster/binary_options');
 const JDLApplication = require('../../../lib/core/jdl_application');
 const JDLUnaryOption = require('../../../lib/core/jdl_unary_option');
 const JDLBinaryOption = require('../../../lib/core/jdl_binary_option');
-const logger = require('../../../lib/utils/objects/logger');
 
 describe('ApplicationValidator', () => {
   let validator;
@@ -241,9 +235,7 @@ describe('ApplicationValidator', () => {
                     }
                   })
                 );
-              }).to.throw(
-                /^Only 'h2Memory', 'h2Disk', 'postgresql' are allowed as devDatabaseType values for databaseType 'sql'\.$/
-              );
+              }).to.throw(/Only 'h2Memory', 'h2Disk', 'postgresql' are allowed as devDatabaseType values\.$/);
             });
           });
           context('with both devDatabaseType and prodDatabaseType as invalid values', () => {
@@ -326,22 +318,6 @@ describe('ApplicationValidator', () => {
               });
             });
           });
-        });
-      });
-      context('with unknown options', () => {
-        let loggerDebug;
-        before(() => {
-          loggerDebug = sinon.spy(logger, 'debug');
-          new JDLApplication({ config: { ...basicValidApplicationConfig, toto: 42 } });
-        });
-        after(() => {
-          loggerDebug.restore();
-        });
-        it('it should send a debug message', () => {
-          expect(loggerDebug).to.have.been.calledOnce;
-          expect(loggerDebug.getCall(0).args[0]).to.equal(
-            'Unrecognized application option name and value: toto and 42'
-          );
         });
       });
       context('with unknown values', () => {

--- a/test/spec/exporters/jdl_exporter.spec.js
+++ b/test/spec/exporters/jdl_exporter.spec.js
@@ -18,12 +18,21 @@
  */
 
 /* eslint-disable no-new, no-unused-expressions */
-const { expect } = require('chai');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+const { expect } = chai;
 
 const fs = require('fs');
+const JCoreDefinitions = require('../../../lib/core/jhipster');
 const ValidatedJDLObject = require('../../../lib/core/validated_jdl_object');
+const JDLObject = require('../../../lib/core/jdl_object');
+const JDLApplication = require('../../../lib/core/jdl_application');
 const JDLEntity = require('../../../lib/core/jdl_entity');
 const JDLExporter = require('../../../lib/exporters/jdl_exporter');
+const logger = require('../../../lib/utils/objects/logger');
 
 describe('JDLExporter', () => {
   describe('exportToJDL', () => {
@@ -92,6 +101,134 @@ describe('JDLExporter', () => {
         it('should write the JDL inside the file', () => {
           expect(jdlContent).to.equal('entity Toto\n');
         });
+      });
+    });
+
+    context('when passing unknown configs', () => {
+      const PATH = 'app.jdl';
+      let fileExistence;
+      let jdlContent;
+      let loggerDebug;
+
+      before(() => {
+        loggerDebug = sinon.spy(logger, 'debug');
+        const jdlApplication = new JDLApplication({
+          config: {
+            baseName: 'toto',
+            toto: 'foo'
+          }
+        });
+        const jdlObject = new JDLObject();
+        jdlObject.addApplication(jdlApplication);
+        JDLExporter.exportToJDL(jdlObject);
+        fileExistence = fs.statSync(PATH).isFile();
+        jdlContent = fs.readFileSync(PATH, 'utf-8').toString();
+      });
+
+      after(() => {
+        fs.unlinkSync(PATH);
+        loggerDebug.restore();
+      });
+
+      it('should export the JDL to the passed path', () => {
+        expect(fileExistence).to.be.true;
+      });
+      it('should write the JDL inside the file', () => {
+        expect(jdlContent).to.not.contain('toto foo\n');
+      });
+      it('should send a debug message', () => {
+        expect(loggerDebug).to.have.been.calledOnce;
+        expect(loggerDebug.getCall(0).args[0]).to.equal('Unrecognized application option name and value: toto and foo');
+      });
+    });
+
+    context('with value that must be quoted', () => {
+      const PATH = 'app.jdl';
+      let fileExistence;
+      let jdlContent = '';
+
+      before(() => {
+        const definitions = new JCoreDefinitions({
+          applicationOptions: {
+            toto: {
+              type: 'string'
+            },
+            foo: {
+              type: 'string'
+            }
+          }
+        });
+        const jdlApplication = new JDLApplication({
+          config: {
+            baseName: 'toto',
+            toto: 'fo$o',
+            foo: 'bar.'
+          },
+          definitions
+        });
+        const jdlObject = new JDLObject();
+        jdlObject.addApplication(jdlApplication);
+        JDLExporter.exportToJDL(jdlObject, PATH, { exportUnregisteredConfigs: true });
+        fileExistence = fs.statSync(PATH).isFile();
+        jdlContent = fs.readFileSync(PATH, 'utf-8').toString();
+      });
+
+      after(() => {
+        fs.unlinkSync(PATH);
+      });
+
+      it('should export the JDL to the passed path', () => {
+        expect(fileExistence).to.be.true;
+      });
+      it('should write \'toto "fo$o"\' inside the file', () => {
+        expect(jdlContent).to.contain('toto "fo$o"\n');
+      });
+      it('should write \'foo "bar."\' inside the file', () => {
+        expect(jdlContent).to.contain('foo "bar."\n');
+      });
+    });
+
+    context('with custom definitions', () => {
+      const PATH = 'app.jdl';
+      let fileExistence;
+      let jdlContent = '';
+      before(() => {
+        const jdlObject = new JDLObject();
+        const definitions = new JCoreDefinitions({
+          applicationOptions: {
+            toto: {
+              type: 'string',
+              values: {
+                foo: 'foo'
+              }
+            }
+          }
+        });
+        const jdlApplication = new JDLApplication({
+          config: {
+            baseName: 'toto',
+            toto: 'foo'
+          },
+          definitions
+        });
+        jdlObject.addApplication(jdlApplication);
+        JDLExporter.exportToJDL(jdlObject, PATH);
+        fileExistence = fs.statSync(PATH).isFile();
+        jdlContent = fs.readFileSync(PATH, 'utf-8').toString();
+      });
+
+      after(() => {
+        fs.unlinkSync(PATH);
+      });
+
+      it('should export the JDL to the passed path', () => {
+        expect(fileExistence).to.be.true;
+      });
+      it("should write 'toto foo' inside the file", () => {
+        expect(jdlContent).to.contain('toto foo\n');
+      });
+      it("should not 'baseName toto' inside the file", () => {
+        expect(jdlContent).to.not.contain('baseName toto\n');
       });
     });
   });

--- a/test/spec/grammar/grammar.spec.js
+++ b/test/spec/grammar/grammar.spec.js
@@ -271,6 +271,71 @@ application {
         });
       });
     });
+    context('when having languages option (permissive option)', () => {
+      context('using value with unquoted', () => {
+        ['!', '#', '$', '%', '^', '&'].forEach(char => {
+          context(char, () => {
+            it('should throw', () => {
+              expect(() =>
+                parseFromContent(`application {
+  config {
+    jwtSecretKey b${char}e
+  }
+}`)
+              ).to.throw(/unexpected character: ->.<-/);
+            });
+          });
+        });
+
+        ['*', '@', '='].forEach(char => {
+          context(char, () => {
+            it('should throw', () => {
+              expect(() =>
+                parseFromContent(`application {
+  config {
+    jwtSecretKey b${char}e
+  }
+}`)
+              ).to.throw(/^MismatchedTokenException: Expecting/);
+            });
+          });
+        });
+        context('-', () => {
+          const char = '-';
+          let application;
+
+          before(() => {
+            const content = parseFromContent(`application {
+                config {
+                nativeLanguage b${char}e
+                }
+            }`);
+            application = content.applications[0];
+          });
+
+          it('should be parsed', () => {
+            expect(application.config.nativeLanguage).to.be.equal(`b${char}e`);
+          });
+        });
+        context('_', () => {
+          const char = '_';
+          let application;
+
+          before(() => {
+            const content = parseFromContent(`application {
+                config {
+                packageName b${char}e
+                }
+            }`);
+            application = content.applications[0];
+          });
+
+          it('should be parsed', () => {
+            expect(application.config.packageName).to.be.equal(`b${char}e`);
+          });
+        });
+      });
+    });
   });
   context('when parsing an entity', () => {
     context('with a name', () => {


### PR DESCRIPTION
Fixes https://github.com/jhipster/jhipster-core/issues/448.

- Allows to externalise validation definitions.
- Allows to extend validation definitions.

Example for additional definitions:
```
importer.import(() => {
  return {
    applicationOptions: {
      clientFramework: {
        values: {
          ionic: 'ionic'
        }
      }
    }
  };
});
```

Please make sure the below checklist is followed for Pull Requests.
  - [ ] Checks are green
  - [ ] Tests are added where necessary
  - [ ] Documentation is added/updated where necessary
  - [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed
