### PR TITLE
A java package name cannot use reserved keywords

### DIFF
--- a/lib/core/jhipster/reserved_keywords.js
+++ b/lib/core/jhipster/reserved_keywords.js
@@ -63,6 +63,10 @@ function isReservedClassName(keyword) {
   );
 }
 
+function isReservedJavaPackageName(pkgName) {
+  return pkgName.split('.').some(pkg => isReserved(pkg, 'JAVA'));
+}
+
 function isReservedTableName(keyword, databaseType) {
   return databaseType.toUpperCase() === 'SQL'
     ? isReserved(keyword, 'MYSQL') ||
@@ -91,6 +95,7 @@ function isReservedFieldName(keyword, clientFramework) {
 module.exports = {
   isReserved,
   isReservedClassName,
+  isReservedJavaPackageName,
   isReservedTableName,
   isReservedFieldName,
   JHIPSTER: ReservedWords.JHIPSTER,

--- a/test/spec/core/jhipster/reserved_keywords.spec.js
+++ b/test/spec/core/jhipster/reserved_keywords.spec.js
@@ -70,6 +70,20 @@ describe('ReservedKeywords', () => {
       });
     });
   });
+  describe('isReservedJavaPackageName', () => {
+    context('when passing a valid package name', () => {
+      it('should return false', () => {
+        expect(ReservedKeywords.isReservedJavaPackageName('com.example.app')).to.be.false;
+        expect(ReservedKeywords.isReservedJavaPackageName('com')).to.be.false;
+      });
+    });
+    context('when passing a package name that uses reserved keywords', () => {
+      it('should return true', () => {
+        expect(ReservedKeywords.isReservedJavaPackageName('com.import')).to.be.true;
+        expect(ReservedKeywords.isReservedJavaPackageName('int')).to.be.true;
+      });
+    });
+  });
   describe('isReservedFieldName', () => {
     context('when passing a valid field name', () => {
       it('should return false', () => {


### PR DESCRIPTION
Please make sure the below checklist is followed for Pull Requests.
  - [ ] Checks are green
  - [x] Tests are added where necessary
  - [x] Documentation is added/updated where necessary
  - [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-core/blob/master/CONTRIBUTING.md) are followed

First part for fixing jhipster/generator-jhipster#12180